### PR TITLE
Add waitUntilComplete() method to Server

### DIFF
--- a/Sources/MCP/Server/Server.swift
+++ b/Sources/MCP/Server/Server.swift
@@ -221,6 +221,7 @@ public actor Server {
                 await logger?.error(
                     "Fatal error in message handling loop", metadata: ["error": "\(error)"])
             }
+            await logger?.info("Server finished", metadata: [:])
         }
     }
 
@@ -232,6 +233,10 @@ public actor Server {
             await connection.disconnect()
         }
         connection = nil
+    }
+
+    public func waitUntilComplete() async {
+        await task?.value
     }
 
     // MARK: - Registration

--- a/Sources/MCP/Server/Server.swift
+++ b/Sources/MCP/Server/Server.swift
@@ -235,7 +235,7 @@ public actor Server {
         connection = nil
     }
 
-    public func waitUntilComplete() async {
+    public func waitUntilCompleted() async {
         await task?.value
     }
 


### PR DESCRIPTION
Adding a small helper method to wait until the serve completes. This is handy when integrating the mcp server into a command line utility.