### PR TITLE
Set permissions for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
     runs-on: macos-latest


### PR DESCRIPTION
Resolves a code scanning alert about the workflow not containing explicit permissions.