### PR TITLE
Update platform requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,11 @@ let package = Package(
     name: "mcp-swift-sdk",
     platforms: [
         .macOS("13.0"),
+        .macCatalyst("16.0"),
         .iOS("16.0"),
+        .watchOS("9.0"),
+        .tvOS("16.0"),
+        .visionOS("1.0"),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.


### PR DESCRIPTION
Resolves #25 

This PR relaxes the platform requirements for macOS (13+) and iOS (16+), and adds support for macOS Catalyst, tvOS, watchOS, and visionOS.