### PR TITLE
Import `System` package when available

### DIFF
--- a/Sources/MCP/Base/Error.swift
+++ b/Sources/MCP/Base/Error.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+#if canImport(System)
+    import System
+#else
+    @preconcurrency import SystemPackage
+#endif
+
 /// A model context protocol error.
 public enum Error: Sendable {
     // Standard JSON-RPC 2.0 errors (-32700 to -32603)
@@ -28,6 +34,20 @@ public enum Error: Sendable {
         case .connectionClosed: return -32000
         case .transportError: return -32001
         }
+    }
+
+    /// Check if an error represents a "resource temporarily unavailable" condition
+    public static func isResourceTemporarilyUnavailable(_ error: Swift.Error) -> Bool {
+        #if canImport(System)
+            if let errno = error as? System.Errno, errno == .resourceTemporarilyUnavailable {
+                return true
+            }
+        #else
+            if let errno = error as? SystemPackage.Errno, errno == .resourceTemporarilyUnavailable {
+                return true
+            }
+        #endif
+        return false
     }
 }
 

--- a/Sources/MCP/Base/Transports.swift
+++ b/Sources/MCP/Base/Transports.swift
@@ -1,8 +1,13 @@
 import Darwin
 import Logging
-import SystemPackage
 
 import struct Foundation.Data
+
+#if canImport(System)
+    import System
+#else
+    @preconcurrency import SystemPackage
+#endif
 
 /// Protocol defining the transport layer for MCP communication
 public protocol Transport: Actor {

--- a/Sources/MCP/Base/Transports.swift
+++ b/Sources/MCP/Base/Transports.swift
@@ -112,7 +112,7 @@ public actor StdioTransport: Transport {
                         messageContinuation.yield(message)
                     }
                 }
-            } catch let error as Errno where error == .resourceTemporarilyUnavailable {
+            } catch let error where Error.isResourceTemporarilyUnavailable(error) {
                 try? await Task.sleep(nanoseconds: 10_000_000)  // 10ms backoff
                 continue
             } catch {
@@ -152,7 +152,7 @@ public actor StdioTransport: Transport {
                 if written > 0 {
                     remaining = remaining.dropFirst(written)
                 }
-            } catch let error as Errno where error == .resourceTemporarilyUnavailable {
+            } catch let error where Error.isResourceTemporarilyUnavailable(error) {
                 try await Task.sleep(nanoseconds: 10_000_000)  // 10ms backoff
                 continue
             } catch {

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -5,12 +5,6 @@ import struct Foundation.Date
 import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
 
-#if canImport(System)
-    import System
-#else
-    @preconcurrency import SystemPackage
-#endif
-
 /// Model Context Protocol client
 public actor Client {
     /// Implementation information
@@ -185,7 +179,7 @@ public actor Client {
                                 "Unexpected message received by client", metadata: metadata)
                         }
                     }
-                } catch let error as Errno where error == .resourceTemporarilyUnavailable {
+                } catch let error where Error.isResourceTemporarilyUnavailable(error) {
                     try? await Task.sleep(nanoseconds: 10_000_000)  // 10ms
                     continue
                 } catch {

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -1,10 +1,15 @@
 import Logging
-import SystemPackage
 
 import struct Foundation.Data
 import struct Foundation.Date
 import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
+
+#if canImport(System)
+    import System
+#else
+    @preconcurrency import SystemPackage
+#endif
 
 /// Model Context Protocol client
 public actor Client {

--- a/Sources/MCP/Server/Server.swift
+++ b/Sources/MCP/Server/Server.swift
@@ -5,12 +5,6 @@ import struct Foundation.Date
 import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
 
-#if canImport(System)
-    import System
-#else
-    @preconcurrency import SystemPackage
-#endif
-
 /// Model Context Protocol server
 public actor Server {
     /// The server configuration
@@ -207,7 +201,7 @@ public actor Server {
                             }
                             throw Error.parseError("Invalid message format")
                         }
-                    } catch let error as Errno where error == .resourceTemporarilyUnavailable {
+                    } catch let error where Error.isResourceTemporarilyUnavailable(error) {
                         // Resource temporarily unavailable, retry after a short delay
                         try? await Task.sleep(nanoseconds: 10_000_000)  // 10ms
                         continue

--- a/Sources/MCP/Server/Server.swift
+++ b/Sources/MCP/Server/Server.swift
@@ -1,10 +1,15 @@
 import Logging
-import SystemPackage
 
 import struct Foundation.Data
 import struct Foundation.Date
 import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
+
+#if canImport(System)
+    import System
+#else
+    @preconcurrency import SystemPackage
+#endif
 
 /// Model Context Protocol server
 public actor Server {

--- a/Tests/MCPTests/RoundtripTests.swift
+++ b/Tests/MCPTests/RoundtripTests.swift
@@ -1,9 +1,14 @@
 import Foundation
 import Logging
-import SystemPackage
 import Testing
 
 @testable import MCP
+
+#if canImport(System)
+    import System
+#else
+    @preconcurrency import SystemPackage
+#endif
 
 @Suite("Roundtrip Tests")
 struct RoundtripTests {

--- a/Tests/MCPTests/TransportTests.swift
+++ b/Tests/MCPTests/TransportTests.swift
@@ -1,8 +1,13 @@
 import Foundation
-import SystemPackage
 import Testing
 
 @testable import MCP
+
+#if canImport(System)
+    import System
+#else
+    @preconcurrency import SystemPackage
+#endif
 
 @Suite("Stdio Transport Tests")
 struct StdioTransportTests {


### PR DESCRIPTION
The MCP SDK depends on the [swift-system](https://github.com/apple/swift-system/) package for its `FileDescriptor` type. However, this creates incompatibilities when attempting to use this library with other libraries like [this experimental `Subprocess` package](https://github.com/iCharlesHu/Subprocess) ([SF-0007](https://github.com/swiftlang/swift-foundation/blob/main/Proposals/0007-swift-subprocess.md)) that conditionally import the `swift-system` package like so:

```swift
#if canImport(System)
    import System
#else
    @preconcurrency import SystemPackage
#endif
```

Trying to use both in the same project results in the following error:

> Cannot convert value of type 'SystemPackage.FileDescriptor' to expected argument type 'System.FileDescriptor'

This PR replaces the existing instances of `import SystemPackage` with the same pattern, which should resolve the issue without any other side effects.

This PR also adds a `isResourceTemporarilyUnavailable` helper method to `MCP.Error` to eliminate the need for `Client` and `Server` to import `System.Errno`. Additional test coverage is provided.

See also https://github.com/apple/swift-system/issues/60