### PR TITLE
Remove deprecated MCP.Error typealias

### DIFF
--- a/Sources/MCP/Base/Error.swift
+++ b/Sources/MCP/Base/Error.swift
@@ -6,20 +6,6 @@ import Foundation
     @preconcurrency import SystemPackage
 #endif
 
-/// Top-level namespace for backward compatibility
-///
-/// This is provided to allow existing code that uses `MCP.Error` to continue
-/// to work without modification.
-///
-/// The MCPError type is now the recommended way to handle errors in MCP.
-///
-/// - Warning: This namespace is deprecated and will be removed in a future version.
-public enum MCP {
-    /// Deprecated type alias for MCPError
-    @available(*, deprecated, renamed: "MCPError", message: "Use MCPError instead of MCP.Error")
-    public typealias Error = MCPError
-}
-
 // MARK: -
 
 /// A model context protocol error.


### PR DESCRIPTION
Follow-up to #44 

This PR removes the temporary `MCP.Error` typealias that was created to mitigate breaking API changes in the [0.7.0 release](https://github.com/modelcontextprotocol/swift-sdk/releases/tag/0.7.0).