### PR TITLE
Update `Client.listTools` return type to include next cursor

### DIFF
--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -364,7 +364,7 @@ public actor Client {
 
     // MARK: - Tools
 
-    public func listTools(cursor: String? = nil) async throws -> [Tool] {
+    public func listTools(cursor: String? = nil) async throws -> (tools: [Tool], nextCursor: String?) {
         try validateServerCapability(\.tools, "Tools")
         let request: Request<ListTools>
         if let cursor = cursor {
@@ -373,7 +373,7 @@ public actor Client {
             request = ListTools.request(.init())
         }
         let result = try await send(request)
-        return result.tools
+        return (tools: result.tools, nextCursor: result.nextCursor)
     }
 
     public func callTool(name: String, arguments: [String: Value]? = nil) async throws -> (

--- a/Tests/MCPTests/RoundtripTests.swift
+++ b/Tests/MCPTests/RoundtripTests.swift
@@ -144,9 +144,9 @@ struct RoundtripTests {
         }
 
         let listToolsTask = Task {
-            let result = try await client.listTools()
-            #expect(result.count == 1)
-            #expect(result[0].name == "add")
+            let (tools, _) = try await client.listTools()
+            #expect(tools.count == 1)
+            #expect(tools[0].name == "add")
         }
 
         let callToolTask = Task {


### PR DESCRIPTION
Resolves #49 

This PR introduces a breaking change to `Client.listTools`, making it return a tuple of `([Tool], String?)`, instead of its current `[Tool]`. This change makes `listTools` consistent with the other list methods, and allows it to support pagination.  


```swift
// New usage
let (tools, nextCursor) = try await client.listTools()


// Old usage
let tools = try await client.listTools()
```