### PR TITLE
Add support for JSON-RPC batching

### DIFF
--- a/Sources/MCP/Base/Messages.swift
+++ b/Sources/MCP/Base/Messages.swift
@@ -30,7 +30,7 @@ public protocol Method {
 }
 
 /// Type-erased method for request/response handling
-struct AnyMethod: Method {
+struct AnyMethod: Method, Sendable {
     static var name: String { "" }
     typealias Parameters = Value
     typealias Result = Value
@@ -139,9 +139,19 @@ extension Request {
 /// A type-erased request for request/response handling
 typealias AnyRequest = Request<AnyMethod>
 
+extension AnyRequest {
+    init<T: Method>(_ request: Request<T>) throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let data = try encoder.encode(request)
+        self = try decoder.decode(AnyRequest.self, from: data)
+    }
+}
+
 /// A box for request handlers that can be type-erased
 class RequestHandlerBox: @unchecked Sendable {
-    func callAsFunction(_ request: Request<AnyMethod>) async throws -> Response<AnyMethod> {
+    func callAsFunction(_ request: AnyRequest) async throws -> AnyResponse {
         fatalError("Must override")
     }
 }
@@ -155,8 +165,7 @@ final class TypedRequestHandler<M: Method>: RequestHandlerBox, @unchecked Sendab
         super.init()
     }
 
-    override func callAsFunction(_ request: Request<AnyMethod>) async throws -> Response<AnyMethod>
-    {
+    override func callAsFunction(_ request: AnyRequest) async throws -> AnyResponse {
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()
 
@@ -238,10 +247,20 @@ public struct Response<M: Method>: Hashable, Identifiable, Codable, Sendable {
 /// A type-erased response for request/response handling
 typealias AnyResponse = Response<AnyMethod>
 
+extension AnyResponse {
+    init<T: Method>(_ response: Response<T>) throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let data = try encoder.encode(response)
+        self = try decoder.decode(AnyResponse.self, from: data)
+    }
+}
+
 // MARK: -
 
 /// A notification message.
-public protocol Notification {
+public protocol Notification: Hashable, Codable, Sendable {
     /// The parameters of the notification.
     associatedtype Parameters: Hashable, Codable, Sendable = Empty
     /// The name of the notification.
@@ -249,9 +268,19 @@ public protocol Notification {
 }
 
 /// A type-erased notification for message handling
-struct AnyNotification: Notification {
+struct AnyNotification: Notification, Sendable {
     static var name: String { "" }
     typealias Parameters = Empty
+}
+
+extension AnyNotification {
+    init(_ notification: some Notification) throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let data = try encoder.encode(notification)
+        self = try decoder.decode(AnyNotification.self, from: data)
+    }
 }
 
 /// A message that can be used to send notifications.

--- a/Tests/MCPTests/Helpers/MockTransport.swift
+++ b/Tests/MCPTests/Helpers/MockTransport.swift
@@ -99,6 +99,15 @@ actor MockTransport: Transport {
         dataToReceive.append(data)
     }
 
+    func queue(batch requests: [AnyRequest]) throws {
+        let data = try encoder.encode(requests)
+        if let continuation = dataStreamContinuation {
+            continuation.yield(data)
+        } else {
+            dataToReceive.append(data)
+        }
+    }
+
     func decodeLastSentMessage<T: Decodable>() -> T? {
         guard let lastMessage = sentData.last else { return nil }
         do {

--- a/Tests/MCPTests/Helpers/MockTransport.swift
+++ b/Tests/MCPTests/Helpers/MockTransport.swift
@@ -80,32 +80,32 @@ actor MockTransport: Transport {
         shouldFailSend = shouldFail
     }
 
-    func queue<M: Method>(request: Request<M>) throws {
-        let data = try encoder.encode(request)
+    func queue(data: Data) {
         if let continuation = dataStreamContinuation {
             continuation.yield(data)
         } else {
             dataToReceive.append(data)
         }
+    }
+
+    func queue<M: Method>(request: Request<M>) throws {
+        queue(data: try encoder.encode(request))
     }
 
     func queue<M: Method>(response: Response<M>) throws {
-        let data = try encoder.encode(response)
-        dataToReceive.append(data)
+        queue(data: try encoder.encode(response))
     }
 
     func queue<N: Notification>(notification: Message<N>) throws {
-        let data = try encoder.encode(notification)
-        dataToReceive.append(data)
+        queue(data: try encoder.encode(notification))
     }
 
     func queue(batch requests: [AnyRequest]) throws {
-        let data = try encoder.encode(requests)
-        if let continuation = dataStreamContinuation {
-            continuation.yield(data)
-        } else {
-            dataToReceive.append(data)
-        }
+        queue(data: try encoder.encode(requests))
+    }
+
+    func queue(batch responses: [AnyResponse]) throws {
+        queue(data: try encoder.encode(responses))
     }
 
     func decodeLastSentMessage<T: Decodable>() -> T? {

--- a/Tests/MCPTests/ResponseTests.swift
+++ b/Tests/MCPTests/ResponseTests.swift
@@ -78,7 +78,7 @@ struct ResponseTests {
             #expect(decodedError.code == -32700)
             #expect(
                 decodedError.localizedDescription
-                    == "Parse error: Invalid JSON: Parse error: Invalid JSON: Invalid syntax")
+                    == "Parse error: Invalid JSON: Invalid syntax")
         } else {
             #expect(Bool(false), "Expected error result")
         }

--- a/Tests/MCPTests/ServerTests.swift
+++ b/Tests/MCPTests/ServerTests.swift
@@ -42,7 +42,7 @@ struct ServerTests {
         try await Task.sleep(nanoseconds: 10_000_000)  // 10ms
 
         #expect(await transport.sentMessages.count == 1)
-        
+
         let messages = await transport.sentMessages
         if let response = messages.first {
             #expect(response.contains("serverInfo"))
@@ -136,7 +136,65 @@ struct ServerTests {
             #expect(response.contains("error"))
             #expect(response.contains("Client not allowed"))
         }
-        
+
+        await server.stop()
+        await transport.disconnect()
+    }
+
+    @Test("JSON-RPC batch processing")
+    func testJSONRPCBatchProcessing() async throws {
+        let transport = MockTransport()
+        let server = Server(name: "TestServer", version: "1.0")
+
+        // Start the server
+        try await server.start(transport: transport)
+
+        // Initialize the server first
+        try await transport.queue(
+            request: Initialize.request(
+                .init(
+                    protocolVersion: Version.latest,
+                    capabilities: .init(),
+                    clientInfo: .init(name: "TestClient", version: "1.0")
+                )
+            )
+        )
+
+        // Wait for server to initialize and respond
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Clear sent messages
+        await transport.clearMessages()
+
+        // Create a batch with multiple requests
+        let batchJSON = """
+            [
+                {"jsonrpc":"2.0","id":1,"method":"ping","params":{}},
+                {"jsonrpc":"2.0","id":2,"method":"ping","params":{}}
+            ]
+            """
+        let batch = try JSONDecoder().decode([AnyRequest].self, from: batchJSON.data(using: .utf8)!)
+
+        // Send the batch request
+        try await transport.queue(batch: batch)
+
+        // Wait for batch processing
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Verify response
+        let sentMessages = await transport.sentMessages
+        #expect(sentMessages.count == 1)
+
+        if let batchResponse = sentMessages.first {
+            // Should be an array
+            #expect(batchResponse.hasPrefix("["))
+            #expect(batchResponse.hasSuffix("]"))
+
+            // Should contain both request IDs
+            #expect(batchResponse.contains("\"id\":1"))
+            #expect(batchResponse.contains("\"id\":2"))
+        }
+
         await server.stop()
         await transport.disconnect()
     }


### PR DESCRIPTION
Resolves #62 

Because `Transport` brokers `Data` objects, it can support sending and receiving JSON-RPC arrays without modification.

`Server` adds an internal `Server.Batch` structure and adds logic to decode arrays received from its transport connection. All user code will work without additional changes.

`Client` adds a public, `Client.Batch` actor, which is passed as an argument to a new `withBatch` method. API consumers can now make multiple requests in a single batch and receive their results asynchronously.

Example 1: Batching multiple tool calls and collecting typed tasks:
```swift
// Array to hold the task handles for each tool call
var toolTasks: [Task<CallTool.Result, Error>] = []
try await client.withBatch { batch in
    for i in 0..<10 {
        toolTasks.append(
            try await batch.addRequest(
                CallTool.request(.init(name: "square", arguments: ["n": i]))
            )
        )
    }
}

// Process results after the batch is sent
print("Processing \(toolTasks.count) tool results...")
for (index, task) in toolTasks.enumerated() {
    do {
        let result = try await task.value
        print("\(index): \(result.content)")
    } catch {
        print("\(index) failed: \(error)")
    }
}
```

Example 2: Batching different request types and awaiting individual tasks:
```swift
// Declare optional task variables beforehand
var pingTask: Task<Ping.Result, Error>?
var promptTask: Task<GetPrompt.Result, Error>?

try await client.withBatch { batch in
    // Assign the tasks within the batch closure
    pingTask = try await batch.addRequest(Ping.request())
    promptTask = try await batch.addRequest(GetPrompt.request(.init(name: "greeting")))
}

// Await the results after the batch is sent
do {
    if let pingTask = pingTask {
        try await pingTask.value // Await ping result (throws if ping failed)
        print("Ping successful")
    }
    if let promptTask = promptTask {
        let promptResult = try await promptTask.value // Await prompt result
        print("Prompt description: \(promptResult.description ?? "None")")
    }
} catch {
    print("Error processing batch results: \(error)")
}
```