### PR TITLE
Simplify `receive()` implementation for transports

### DIFF
--- a/Sources/MCP/Base/Transports/HTTPClientTransport.swift
+++ b/Sources/MCP/Base/Transports/HTTPClientTransport.swift
@@ -148,14 +148,7 @@ public actor HTTPClientTransport: Actor, Transport {
 
     /// Receives data in an async sequence
     public func receive() -> AsyncThrowingStream<Data, Swift.Error> {
-        return AsyncThrowingStream { continuation in
-            Task {
-                for try await message in messageStream {
-                    continuation.yield(message)
-                }
-                continuation.finish()
-            }
-        }
+        return messageStream
     }
 
     // MARK: - SSE

--- a/Sources/MCP/Base/Transports/NetworkTransport.swift
+++ b/Sources/MCP/Base/Transports/NetworkTransport.swift
@@ -159,18 +159,7 @@ import struct Foundation.Data
         }
 
         public func receive() -> AsyncThrowingStream<Data, Swift.Error> {
-            return AsyncThrowingStream { continuation in
-                Task {
-                    do {
-                        for try await message in messageStream {
-                            continuation.yield(message)
-                        }
-                        continuation.finish()
-                    } catch {
-                        continuation.finish(throwing: error)
-                    }
-                }
-            }
+            return messageStream
         }
 
         private func receiveLoop() async {

--- a/Sources/MCP/Base/Transports/StdioTransport.swift
+++ b/Sources/MCP/Base/Transports/StdioTransport.swift
@@ -29,8 +29,8 @@ import struct Foundation.Data
         public nonisolated let logger: Logger
 
         private var isConnected = false
-        private let messageStream: AsyncStream<Data>
-        private let messageContinuation: AsyncStream<Data>.Continuation
+        private let messageStream: AsyncThrowingStream<Data, Swift.Error>
+        private let messageContinuation: AsyncThrowingStream<Data, Swift.Error>.Continuation
 
         public init(
             input: FileDescriptor = FileDescriptor.standardInput,
@@ -46,8 +46,8 @@ import struct Foundation.Data
                     factory: { _ in SwiftLogNoOpLogHandler() })
 
             // Create message stream
-            var continuation: AsyncStream<Data>.Continuation!
-            self.messageStream = AsyncStream { continuation = $0 }
+            var continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation!
+            self.messageStream = AsyncThrowingStream { continuation = $0 }
             self.messageContinuation = continuation
         }
 
@@ -177,14 +177,7 @@ import struct Foundation.Data
         /// or batches containing multiple requests/notifications encoded as JSON arrays.
         /// Each message is guaranteed to be a complete JSON object or array.
         public func receive() -> AsyncThrowingStream<Data, Swift.Error> {
-            return AsyncThrowingStream { continuation in
-                Task {
-                    for await message in messageStream {
-                        continuation.yield(message)
-                    }
-                    continuation.finish()
-                }
-            }
+            return messageStream
         }
     }
 #endif


### PR DESCRIPTION
The built-in transports currently implement the `receive()` method by creating a new `AsyncThrowingStream` that wraps an underlying `messageStream`. This is unnecessary since `messageStream` is already an `AsyncThrowingStream` that we can return directly.

This PR makes this change.

In the case of `StdioTransport`, this also changes the underlying message stream from `AsyncStream` to `AsyncThrowingStream`.
