### PR TITLE
Update AnyNotification to include notification params

### DIFF
--- a/Sources/MCP/Base/Messages.swift
+++ b/Sources/MCP/Base/Messages.swift
@@ -325,10 +325,11 @@ public struct Message<N: Notification>: Hashable, Codable, Sendable {
         }
         method = try container.decode(String.self, forKey: .method)
 
-        // Handle params field being optional
-        if N.Parameters.self == Empty.self {
-            // For Empty parameters, use Empty() if params is missing or null
-            params = Empty() as! N.Parameters
+        if N.Parameters.self is NotRequired.Type {
+            // For NotRequired parameters, use decodeIfPresent or init()
+            params =
+                (try container.decodeIfPresent(N.Parameters.self, forKey: .params)
+                    ?? (N.Parameters.self as! NotRequired.Type).init() as! N.Parameters)
         } else if let value = try? container.decode(N.Parameters.self, forKey: .params) {
             // If params exists and can be decoded, use it
             params = value

--- a/Sources/MCP/Base/Messages.swift
+++ b/Sources/MCP/Base/Messages.swift
@@ -278,7 +278,7 @@ public protocol Notification: Hashable, Codable, Sendable {
 /// A type-erased notification for message handling
 struct AnyNotification: Notification, Sendable {
     static var name: String { "" }
-    typealias Parameters = Empty
+    typealias Parameters = Value
 }
 
 extension AnyNotification {

--- a/Tests/MCPTests/NotificationTests.swift
+++ b/Tests/MCPTests/NotificationTests.swift
@@ -86,4 +86,30 @@ struct NotificationTests {
 
         #expect(decoded.method == InitializedNotification.name)
     }
+
+    @Test("Resource updated notification with parameters")
+    func testResourceUpdatedNotification() throws {
+        let params = ResourceUpdatedNotification.Parameters(uri: "test://resource")
+        let notification = ResourceUpdatedNotification.message(params)
+
+        #expect(notification.method == ResourceUpdatedNotification.name)
+        #expect(notification.params.uri == "test://resource")
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let data = try encoder.encode(notification)
+
+        // Verify the exact JSON structure
+        let json = try JSONDecoder().decode([String: Value].self, from: data)
+        #expect(json["jsonrpc"] == "2.0")
+        #expect(json["method"] == "notifications/resources/updated")
+        #expect(json["params"] != nil)
+        #expect(json.count == 3, "Should contain jsonrpc, method, and params fields")
+
+        // Verify we can decode it back
+        let decoded = try decoder.decode(Message<ResourceUpdatedNotification>.self, from: data)
+        #expect(decoded.method == ResourceUpdatedNotification.name)
+        #expect(decoded.params.uri == "test://resource")
+    }
 }

--- a/Tests/MCPTests/NotificationTests.swift
+++ b/Tests/MCPTests/NotificationTests.swift
@@ -112,4 +112,61 @@ struct NotificationTests {
         #expect(decoded.method == ResourceUpdatedNotification.name)
         #expect(decoded.params.uri == "test://resource")
     }
+
+    @Test("AnyNotification decoding - without params")
+    func testAnyNotificationDecodingWithoutParams() throws {
+        // Test decoding when params field is missing
+        let jsonString = """
+            {"jsonrpc":"2.0","method":"notifications/initialized"}
+            """
+        let data = jsonString.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(AnyMessage.self, from: data)
+
+        #expect(decoded.method == InitializedNotification.name)
+    }
+
+    @Test("AnyNotification decoding - with null params")
+    func testAnyNotificationDecodingWithNullParams() throws {
+        // Test decoding when params field is null
+        let jsonString = """
+            {"jsonrpc":"2.0","method":"notifications/initialized","params":null}
+            """
+        let data = jsonString.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(AnyMessage.self, from: data)
+
+        #expect(decoded.method == InitializedNotification.name)
+    }
+
+    @Test("AnyNotification decoding - with empty params")
+    func testAnyNotificationDecodingWithEmptyParams() throws {
+        // Test decoding when params field is empty
+        let jsonString = """
+            {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+            """
+        let data = jsonString.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(AnyMessage.self, from: data)
+
+        #expect(decoded.method == InitializedNotification.name)
+    }
+
+    @Test("AnyNotification decoding - with non-empty params")
+    func testAnyNotificationDecodingWithNonEmptyParams() throws {
+        // Test decoding when params field has values
+        let jsonString = """
+            {"jsonrpc":"2.0","method":"notifications/resources/updated","params":{"uri":"test://resource"}}
+            """
+        let data = jsonString.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(AnyMessage.self, from: data)
+
+        #expect(decoded.method == ResourceUpdatedNotification.name)
+        #expect(decoded.params.objectValue?["uri"]?.stringValue == "test://resource")
+    }
 }


### PR DESCRIPTION
## Motivation and Context
When the client receives a notification from the server, the params that are included are not accessible from the client. It appears they were intended to be considering the README (specifcally the ResourceUpdatedNotification example), but they in fact come through as an instance of Empty(). 

## How Has This Been Tested?
Example note...
```
event: message
id: _GET_stream_1745335731559_yxppqadb
data: {"method":"notifications/message","jsonrpc":"2.0","params":{"level":"info","data":"Hello, world! 2025-04-22T15:28:51.558Z"}}
```
Example client code 

```swift
struct GenericNotification: MCP.Notification, Sendable {
    static var name: String { "notifications/message" }
}
...
await client.onNotification(GenericNotification.self) { message in
    print("NOTE PARAMS: \(message.params)") // prints Empty()
}
```

```swift
struct GenericNotification: MCP.Notification, Sendable {
    static var name: String { "notifications/message" }
    typealias Parameters = Value
}
...
await client.onNotification(GenericNotification.self) { message in
    print("NOTE PARAMS: \(message.params.data)") // prints ["level": info, "data": Hello, world! 2025-04-22T16:34:14.059Z]
}
```

```swift
struct GenericNotification: MCP.Notification, Sendable {
    static var name: String { "notifications/message" }
    
    public struct Parameters: Hashable, Codable, Sendable {
        let level:String
        let data:String
    }
}
...
await client.onNotification(GenericNotification.self) { message in
    print("NOTE PARAMS: \(message.params.data)") // prints Hello, world! 2025-04-22T15:29:31.652Z
}
```

## Breaking Changes
none

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [n/a] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

