### PR TITLE
Fix event stream line parsing to handle CRLF and empty lines correctly

### DIFF
--- a/Sources/MCP/Base/Transports/HTTPClientTransport.swift
+++ b/Sources/MCP/Base/Transports/HTTPClientTransport.swift
@@ -179,117 +179,107 @@ public actor HTTPClientTransport: Actor, Transport {
         /// Establishes an SSE connection to the server
         private func connectToEventStream() async throws {
             guard isConnected else { return }
-
+            
             var request = URLRequest(url: endpoint)
             request.httpMethod = "GET"
             request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
-
+            
             // Add session ID if available
             if let sessionID = sessionID {
                 request.addValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
             }
-
+            
             // Add Last-Event-ID header for resumability if available
             if let lastEventID = lastEventID {
                 request.addValue(lastEventID, forHTTPHeaderField: "Last-Event-ID")
             }
-
+            
             logger.debug("Starting SSE connection")
-
+            
             // Create URLSession task for SSE
             let (stream, response) = try await session.bytes(for: request)
-
+            
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw MCPError.internalError("Invalid HTTP response")
             }
-
+            
             // Check response status
             guard httpResponse.statusCode == 200 else {
                 throw MCPError.internalError("HTTP error: \(httpResponse.statusCode)")
             }
-
+            
             // Extract session ID if present
             if let newSessionID = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id") {
                 self.sessionID = newSessionID
             }
-
+            
             // Process the SSE stream
-            var buffer = ""
             var eventType = ""
             var eventID: String?
             var eventData = ""
-
-            for try await byte in stream {
+            
+            for try await line in stream.lines {
                 if Task.isCancelled { break }
-
-                guard let char = String(bytes: [byte], encoding: .utf8) else { continue }
-                buffer.append(char)
-
-                // Process complete lines
-                while let newlineIndex = buffer.firstIndex(of: "\n") {
-                    let line = buffer[..<newlineIndex]
-                    buffer = String(buffer[buffer.index(after: newlineIndex)...])
-
-                    // Empty line marks the end of an event
-                    if line.isEmpty || line == "\r" || line == "\n" || line == "\r\n" {
-                        if !eventData.isEmpty {
-                            // Process the event
-                            if eventType == "id" {
-                                lastEventID = eventID
-                            } else {
-                                // Default event type is "message" if not specified
-                                if let data = eventData.data(using: .utf8) {
-                                    logger.debug(
-                                        "SSE event received",
-                                        metadata: [
-                                            "type": "\(eventType.isEmpty ? "message" : eventType)",
-                                            "id": "\(eventID ?? "none")",
-                                        ])
-                                    messageContinuation.yield(data)
-                                }
+                
+                // Empty line marks the end of an event
+                if line.isEmpty {
+                    if !eventData.isEmpty {
+                        // Process the event
+                        if eventType == "id" {
+                            lastEventID = eventID
+                        } else {
+                            // Default event type is "message" if not specified
+                            if let data = eventData.data(using: .utf8) {
+                                logger.debug(
+                                    "SSE event received",
+                                    metadata: [
+                                        "type": "\(eventType.isEmpty ? "message" : eventType)",
+                                        "id": "\(eventID ?? "none")",
+                                    ])
+                                messageContinuation.yield(data)
                             }
-
-                            // Reset for next event
-                            eventType = ""
-                            eventData = ""
                         }
-                        continue
+                        
+                        // Reset for next event
+                        eventType = ""
+                        eventData = ""
                     }
-
-                    // Lines starting with ":" are comments
-                    if line.hasPrefix(":") { continue }
-
-                    // Parse field: value format
-                    if let colonIndex = line.firstIndex(of: ":") {
-                        let field = String(line[..<colonIndex])
-                        var value = String(line[line.index(after: colonIndex)...])
-
-                        // Trim leading space
-                        if value.hasPrefix(" ") {
-                            value = String(value.dropFirst())
+                    continue
+                }
+                
+                // Lines starting with ":" are comments
+                if line.hasPrefix(":") { continue }
+                
+                // Parse field: value format
+                if let colonIndex = line.firstIndex(of: ":") {
+                    let field = String(line[..<colonIndex])
+                    var value = String(line[line.index(after: colonIndex)...])
+                    
+                    // Trim leading space
+                    if value.hasPrefix(" ") {
+                        value = String(value.dropFirst())
+                    }
+                    
+                    // Process based on field
+                    switch field {
+                    case "event":
+                        eventType = value
+                    case "data":
+                        if !eventData.isEmpty {
+                            eventData.append("\n")
                         }
-
-                        // Process based on field
-                        switch field {
-                        case "event":
-                            eventType = value
-                        case "data":
-                            if !eventData.isEmpty {
-                                eventData.append("\n")
-                            }
-                            eventData.append(value)
-                        case "id":
-                            if !value.contains("\0") {  // ID must not contain NULL
-                                eventID = value
-                                lastEventID = value
-                            }
-                        case "retry":
-                            // Retry timing not implemented
-                            break
-                        default:
-                            // Unknown fields are ignored per SSE spec
-                            break
+                        eventData.append(value)
+                    case "id":
+                        if !value.contains("\0") {  // ID must not contain NULL
+                            eventID = value
+                            lastEventID = value
                         }
+                    case "retry":
+                        // Retry timing not implemented
+                        break
+                    default:
+                        // Unknown fields are ignored per SSE spec
+                        break
                     }
                 }
             }

--- a/Tests/MCPTests/HTTPClientTransportTests.swift
+++ b/Tests/MCPTests/HTTPClientTransportTests.swift
@@ -413,6 +413,40 @@ import Testing
 
                 #expect(receivedData == expectedData)
             }
+            @Test("Receive Server-Sent Event (SSE) (CR-NL)", .httpClientTransportSetup)
+            func testReceiveSSE_CRNL() async throws {
+                let configuration = URLSessionConfiguration.ephemeral
+                configuration.protocolClasses = [MockURLProtocol.self]
+
+                let transport = HTTPClientTransport(
+                    endpoint: testEndpoint, configuration: configuration, streaming: true,
+                    logger: nil)
+
+                let eventString = "id: event1\r\ndata: {\"key\":\"value\"}\r\n\n"
+                let sseEventData = eventString.data(using: .utf8)!
+
+                await MockURLProtocol.requestHandlerStorage.setHandler {
+                    [testEndpoint] (request: URLRequest) in
+                    #expect(request.url == testEndpoint)
+                    #expect(request.httpMethod == "GET")
+                    #expect(request.value(forHTTPHeaderField: "Accept") == "text/event-stream")
+                    let response = HTTPURLResponse(
+                        url: testEndpoint, statusCode: 200, httpVersion: "HTTP/1.1",
+                        headerFields: ["Content-Type": "text/event-stream"])!
+                    return (response, sseEventData)
+                }
+
+                try await transport.connect()
+                try await Task.sleep(for: .milliseconds(100))
+
+                let stream = await transport.receive()
+                var iterator = stream.makeAsyncIterator()
+
+                let expectedData = #"{"key":"value"}"#.data(using: .utf8)!
+                let receivedData = try await iterator.next()
+
+                #expect(receivedData == expectedData)
+            }
         #endif  // !canImport(FoundationNetworking)
     }
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Optimized code in `connectToEventStream` to use `.lines` computed value of `AsyncSequence` to produce a `AsyncLineSequence` instead of building a lines manually.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Optimization

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
