### PR TITLE
support 405 response from servers that don’t support streaming

### DIFF
--- a/Sources/MCP/Base/Transports/HTTPClientTransport.swift
+++ b/Sources/MCP/Base/Transports/HTTPClientTransport.swift
@@ -205,6 +205,12 @@ public actor HTTPClientTransport: Actor, Transport {
 
             // Check response status
             guard httpResponse.statusCode == 200 else {
+                // For servers that don't support streaming from this endpoint
+                // they should return a 405 NOT ALLOWED. So lets cancel the task
+                // instead of retrying
+                if httpResponse.statusCode == 405 {
+                    self.streamingTask?.cancel()
+                }
                 throw MCPError.internalError("HTTP error: \(httpResponse.statusCode)")
             }
 

--- a/Sources/MCP/Base/Transports/HTTPClientTransport.swift
+++ b/Sources/MCP/Base/Transports/HTTPClientTransport.swift
@@ -205,9 +205,9 @@ public actor HTTPClientTransport: Actor, Transport {
 
             // Check response status
             guard httpResponse.statusCode == 200 else {
-                // For servers that don't support streaming from this endpoint
-                // they should return a 405 NOT ALLOWED. So lets cancel the task
-                // instead of retrying
+                // If the server returns 405 Method Not Allowed,
+                // it indicates that the server doesn't support SSE streaming.
+                // We should cancel the task instead of retrying the connection.
                 if httpResponse.statusCode == 405 {
                     self.streamingTask?.cancel()
                 }


### PR DESCRIPTION

## Motivation and Context
Some MCP servers do not support streaming from the GET. They should return a 405 to denote that lack of support. Currently the client retries on errors and should not retry if it knows the server does not support it.

## How Has This Been Tested?
Stood up a server using the latest TS SDK from Anthropic configured to not support

## Breaking Changes
none

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed


