### PR TITLE
Handle streamable POSTs to properly support new streamable transport protocol spec

### DIFF
--- a/Sources/MCP/Base/Transports/HTTPClientTransport.swift
+++ b/Sources/MCP/Base/Transports/HTTPClientTransport.swift
@@ -205,6 +205,12 @@ public actor HTTPClientTransport: Actor, Transport {
 
             // Check response status
             guard httpResponse.statusCode == 200 else {
+                // For servers that don't support streaming from this endpoint
+                // they should return a 405 NOT ALLOWED. So lets cancel the task
+                // instead of retrying
+                if httpResponse.statusCode == 405 {
+                    self.streamingTask?.cancel()
+                }
                 throw MCPError.internalError("HTTP error: \(httpResponse.statusCode)")
             }
 


### PR DESCRIPTION
The streamable http transport spec handles SSE a bit different than the original sse transport spec.  In the original spec, POSTs returned their responses as sse messages on the GET stream. Now the POSTs themselves can sse streams so the GET becomes primarily for notifications (or resuming a POST that experienced a broken connection, but thats a separate can of worms that has not been properly addressed yet). 

## Motivation and Context
The current HTTPClientTransport does not support streams coming back from POSTs and it must to work with latest spec servers. 

## How Has This Been Tested?
We have 3 sandbox servers set up with latest server sdk from anthropic. Each configured differently to exercise expected variations.  

// streaming response + session management
https://hgai-sandbox.aks.stage.mercury.io/streamable/mcp

// JSON response + session management
https://hgai-sandbox.aks.stage.mercury.io/streamable/json/mcp

// JSON response with no session management
https://hgai-sandbox.aks.stage.mercury.io/streamable/stateless/mcp

## Breaking Changes
none

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Supporting true resumability will require some additional work that was beyond the scope of this initial PR
