### PR TITLE
Schema-Based Tool Registration and Handling

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "cce36cb33302c2f1c28458e19b8439f736fc28106e4c6ea95d7992c74594c242",
+  "originHash" : "8375176f0e64ba7d128bf657147c408dc96035d49440183a1f643c94e3f77122",
   "pins" : [
+    {
+      "identity" : "swift-json-schema",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ajevans99/swift-json-schema",
+      "state" : {
+        "revision" : "2ba78e486722955e0147574fb6806027abb29faa",
+        "version" : "0.4.0"
+      }
+    },
     {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,15 @@
       "state" : {
         "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
         "version" : "1.6.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -6,22 +6,24 @@ import PackageDescription
 let package = Package(
     name: "mcp-swift-sdk",
     platforms: [
-        .macOS("13.0"),
-        .macCatalyst("16.0"),
-        .iOS("16.0"),
-        .watchOS("9.0"),
-        .tvOS("16.0"),
-        .visionOS("1.0"),
+        .macOS(.v14),
+        .macCatalyst(.v17),
+        .iOS(.v17),
+        .watchOS(.v10),
+        .tvOS(.v17),
+        .visionOS(.v1),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "MCP",
-            targets: ["MCP"])
+            targets: ["MCP", "SchemaMCP"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-system.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+        .package(url: "https://github.com/ajevans99/swift-json-schema", from: "0.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -31,13 +33,36 @@ let package = Package(
             dependencies: [
                 .product(name: "SystemPackage", package: "swift-system"),
                 .product(name: "Logging", package: "swift-log"),
-            ]),
+            ],
+            path: "Sources/MCP"
+        ),
         .testTarget(
             name: "MCPTests",
             dependencies: [
                 "MCP",
                 .product(name: "SystemPackage", package: "swift-system"),
                 .product(name: "Logging", package: "swift-log"),
-            ]),
+            ],
+            path: "Tests/MCPTests"
+        ),
+        .target(
+            name: "SchemaMCP",
+            dependencies: [
+                "MCP",
+                .product(name: "JSONSchema", package: "swift-json-schema"),
+                .product(name: "JSONSchemaBuilder", package: "swift-json-schema"),
+            ],
+            path: "SchemaMCP/Sources"
+        ),
+        .testTarget(
+            name: "SchemaMCPTests",
+            dependencies: [
+                "MCP",
+                "SchemaMCP",
+                .product(name: "JSONSchema", package: "swift-json-schema"),
+                .product(name: "JSONSchemaBuilder", package: "swift-json-schema"),
+            ],
+            path: "SchemaMCP/Tests"
+        ),
     ]
 )

--- a/SchemaMCP/Sources/SchemaTool.swift
+++ b/SchemaMCP/Sources/SchemaTool.swift
@@ -1,0 +1,156 @@
+import Foundation
+import JSONSchema
+import JSONSchemaBuilder
+import MCP
+
+public extension Server {
+    /// Registers a toolbox of tools with the server.
+    /// - Parameter toolBox: The toolbox to register.
+    /// - Returns: The server instance for chaining.
+    @discardableResult
+    func withTools<each S>(
+        _ toolBox: ToolBox< repeat each S>
+    ) -> Self {
+        withMethodHandler(ListTools.self) { parameters in
+            try .init(tools: toolBox.mcpTools(), nextCursor: parameters.cursor)
+        }
+
+        return withMethodHandler(CallTool.self) { call in
+            for tool in repeat each toolBox.tools {
+                if call.name == tool.name {
+                    let result = try await tool.handler(call.arguments)
+                    return result
+                }
+            }
+
+            return .init(content: [.text("Tool \(call.name) not found")], isError: true)
+        }
+    }
+}
+
+/// A toolbox holding a variadic list of schema tools.
+public struct ToolBox<each T: Schemable>: Sendable {
+    /// The tuple of tools.
+    public let tools: (repeat SchemaTool<each T>)
+
+    /// Initializes a toolbox with the given tools.
+    /// - Parameter tools: The tuple of tools.
+    public init(tools: (repeat SchemaTool<each T>)) {
+        self.tools = tools
+    }
+
+    /// Converts all tools to MCP tool definitions.
+    /// - Throws: `MCPError` if any conversion fails.
+    public func mcpTools() throws(MCPError) -> [Tool] {
+        var mcpTools: [Tool] = []
+        for tool in repeat (each tools) {
+            try mcpTools.append(tool.toMCPTool())
+        }
+        return mcpTools
+    }
+}
+
+/// Represents a tool with a schema-based input and async handler.
+public struct SchemaTool<Schema: Schemable>: Identifiable, Sendable {
+    /// The tool name.
+    public let name: String
+    /// The tool description.
+    public let description: String
+    /// The tool input schema type.
+    public let inputType: Schema.Type
+    /// The tool handler.
+    private let handlerClosure: @Sendable (Schema) async throws -> CallTool.Result
+    /// Schema used to parse or validate input.
+    private let inputSchema: Schema.Schema
+
+    /// The tool's unique identifier (same as name).
+    public var id: String { name }
+
+    /// Parses arguments into the schema type.
+    /// - Parameter arguments: The arguments to parse.
+    /// - Throws: `MCPError.parseError` if parsing fails or type mismatch.
+    public func parse(_ arguments: [String: Value]?) throws(MCPError) -> Schema {
+        let output = try inputSchema.parse(arguments)
+        guard let schema = output as? Schema else {
+            throw MCPError.parseError("Schema.Schema.Output != Schema")
+        }
+        return schema
+    }
+
+    /// Handles a tool call with arguments.
+    /// - Parameter arguments: The arguments to handle.
+    /// - Returns: The result of the tool call.
+    public func handler(
+        _ arguments: [String: Value]?
+    ) async throws -> CallTool.Result {
+        do {
+            let output = try inputSchema.parse(arguments)
+            guard let schema = output as? Schema else {
+                throw MCPError.parseError("Schema.Schema.Output != Schema")
+            }
+            return try await handlerClosure(schema)
+        } catch {
+            return .init(content: [.text("Failed to parse arguments: \(error)")], isError: true)
+        }
+    }
+
+    /// Initializes a new `SchemaTool`.
+    /// - Parameters:
+    ///   - name: The tool name.
+    ///   - description: The tool description.
+    ///   - inputType: The schema type for input.
+    ///   - handler: The async handler closure.
+    public init(
+        name: String,
+        description: String,
+        inputType: Schema.Type,
+        handler: @escaping @Sendable (Schema) async throws -> CallTool.Result
+    ) {
+        self.name = name
+        self.description = description
+        self.inputType = inputType
+        handlerClosure = handler
+        inputSchema = inputType.schema
+    }
+
+    /// Converts the tool to an MCP tool definition.
+    /// - Throws: `MCPError` if conversion fails.
+    public func toMCPTool() throws(MCPError) -> Tool {
+        try .init(
+            name: name,
+            description: description,
+            inputSchema: .init(schema: inputSchema)
+        )
+    }
+}
+
+/// Extension to initialize `Value` from a JSONSchemaComponent.
+public extension Value {
+    /// Initializes a `Value` from a schema component.
+    /// - Parameter schema: The schema component to encode.
+    /// - Throws: `MCPError.parseError` if encoding or decoding fails.
+    init(schema: some JSONSchemaComponent) throws(MCPError) {
+        do {
+            let data = try JSONEncoder().encode(schema.definition())
+            self = try JSONDecoder().decode(Value.self, from: data)
+        } catch {
+            throw MCPError.parseError("Invalid schema: \(error)")
+        }
+    }
+}
+
+/// Extension to parse arguments using a JSONSchemaComponent.
+public extension JSONSchemaComponent {
+    /// Parses and validates arguments using the schema.
+    /// - Parameter arguments: The arguments to parse.
+    /// - Throws: `MCPError.invalidParams` if parsing fails.
+    func parse(_ arguments: [String: Value]?) throws(MCPError) -> Output {
+        do {
+            let data = try JSONEncoder().encode(arguments)
+            let string = String(data: data, encoding: .utf8) ?? ""
+            return try parseAndValidate(instance: string)
+        } catch {
+            throw MCPError.invalidParams("Failed to parse arguments: \(error)")
+        }
+    }
+}

--- a/SchemaMCP/Tests/Test.swift
+++ b/SchemaMCP/Tests/Test.swift
@@ -1,0 +1,121 @@
+import Foundation
+import JSONSchema
+import JSONSchemaBuilder
+@testable import MCP
+@testable import SchemaMCP
+import Testing
+
+@Schemable
+struct HelloInput {
+    @SchemaOptions(description: "The name to say hello to", examples: "World")
+    let name: String
+}
+
+@Schemable
+struct AddInput {
+    @SchemaOptions(description: "The first number to add")
+    let a: Int
+
+    @SchemaOptions(description: "The second number to add")
+    let b: Int
+}
+
+@Schemable
+struct EchoInput {
+    @SchemaOptions(description: "The message to echo")
+    let message: String
+}
+
+@Suite("Schema Tool Tests")
+struct SchemaToolTests {
+    @Test func schemaToTool() async throws {
+        let schemaTool = SchemaTool(
+            name: "test",
+            description: "Test tool",
+            inputType: HelloInput.self,
+            handler: { input in
+                .init(content: [.text("Hello, \(input.name)")], isError: false)
+            }
+        )
+        let tool = try schemaTool.toMCPTool()
+
+        #expect(tool.name == "test")
+        #expect(tool.description == "Test tool")
+
+        let inputSchema: Value = .object([
+            "required": .array([.string("name")]),
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object([
+                    "type": .string("string"),
+                    "description": .string("The name to say hello to"),
+                    "examples": .string("World"),
+                ]),
+            ]),
+        ])
+        #expect(tool.inputSchema == inputSchema)
+    }
+
+    @Test func parsesInputCorrectly() async throws {
+        let tool = SchemaTool(
+            name: "add",
+            description: "Add two numbers",
+            inputType: AddInput.self,
+            handler: { input in
+                .init(content: [.text("Sum: \(input.a + input.b)")])
+            }
+        )
+        let args: [String: Value] = ["a": .int(2), "b": .int(3)]
+        let parsed = try tool.parse(args)
+        #expect(parsed.a == 2)
+        #expect(parsed.b == 3)
+    }
+
+    @Test func handlerReturnsExpectedResult() async throws {
+        let tool = SchemaTool(
+            name: "echo",
+            description: "Echo a message",
+            inputType: EchoInput.self,
+            handler: { input in
+                .init(content: [.text(input.message)])
+            }
+        )
+        let args: [String: Value] = ["message": .string("hi!")]
+        let result = try await tool.handler(args)
+        #expect(result.content == [.text("hi!")])
+    }
+
+    @Test func handlerReturnsErrorOnInvalidInput() async throws {
+        let tool = SchemaTool(
+            name: "add",
+            description: "Add two numbers",
+            inputType: AddInput.self,
+            handler: { input in
+                .init(content: [.text("Sum: \(input.a + input.b)")])
+            }
+        )
+        let args: [String: Value] = ["a": .string("oops"), "b": .int(3)]
+        let result = try await tool.handler(args)
+        #expect(result.isError == true)
+    }
+
+    @Test func toolBoxMcpToolsReturnsAll() async throws {
+        let addTool = SchemaTool(
+            name: "add",
+            description: "Add two numbers",
+            inputType: AddInput.self,
+            handler: { _ in .init(content: [.text("")]) }
+        )
+        let echoTool = SchemaTool(
+            name: "echo",
+            description: "Echo a message",
+            inputType: EchoInput.self,
+            handler: { _ in .init(content: [.text("")]) }
+        )
+        let box = ToolBox(tools: (addTool, echoTool))
+        let mcpTools = try box.mcpTools()
+        #expect(mcpTools.count == 2)
+        #expect(mcpTools[0].name == "add" || mcpTools[1].name == "add")
+        #expect(mcpTools[0].name == "echo" || mcpTools[1].name == "echo")
+    }
+}


### PR DESCRIPTION
## Overview

Introduces the `@Schemable` macro for type-safe, schema-driven tool handling in MCP servers.

## Key Features

- **Type Safety**: Built-in argument validation with error reporting
- **Server Extension**: Adds a `withTools` method that automatically configures MCP's `listTools` and `callTool` methods.
- **SchemaTool**: A generic struct for defining tools with a schema-based input and async handler.
- **ToolBox**: A variadic container for grouping multiple `SchemaTool` instances, allowing batch registration with the server.

## Example Usage

```swift
@Schemable
struct EchoInput {
    @SchemaOptions(description: "The message to echo")
    let message: String
}

let echoTool = SchemaTool(
    name: "echo",
    description: "Echoes back the input string.",
    inputType: EchoInput.self
) { input in
    .init(content: [.text(input.message)], isError: false)
}

server.withTools(ToolBox(tools: (echoTool)))
```

## Motivation
- **Safety**: Ensures all tool invocations are validated against a schema, reducing runtime errors.
- **Efficient**: Makes it easy to add new tools with minimal boilerplate.

## Implementation

- Includes schema parsing and MCP tool conversion utilities
- Uses Swift’s variadic generics for ergonomic tool registration.
- Seamless integration with existing MCP server and tool protocols.

## How Has This Been Tested?

<!-- Have you tested this in a real application? Which scenarios were tested? -->

Unit test in `SchemaMCP/Tests/Test.swift`. Already tested in a real application.

## Breaking Changes

> Important:
> 
> 
> **This PR introduces a dependency on the `swift-json-schema` library, which has higher minimum OS version requirements than the current library.**
>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Design Inspiration

This interface's design draws inspiration from best practices found in two major MCP libraries:

- [jlowin/fastmcp](https://github.com/jlowin/fastmcp)
- [modelcontextprotocol/typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk)

## Additional context

I'm opening this PR directly for discussion purposes. Since the implementation is relatively small (primarily in `SchemaTool.swift`), I believe it's more efficient to discuss the actual code.
**Note that this branch is intended for discussion only, as the `swift-json-schema` dependency requires a higher minimum version than our current library supports.**
