### PR TITLE
Handle endpoint event

### DIFF
--- a/Sources/MCP/Base/Transports/HTTPClientTransport.swift
+++ b/Sources/MCP/Base/Transports/HTTPClientTransport.swift
@@ -2,22 +2,22 @@ import Foundation
 import Logging
 
 #if canImport(FoundationNetworking)
-    import FoundationNetworking
+import FoundationNetworking
 #endif
 
 public actor HTTPClientTransport: Actor, Transport {
-    public let endpoint: URL
+    private(set) public var endpoint: URL
     private let session: URLSession
     public private(set) var sessionID: String?
     private let streaming: Bool
     private var streamingTask: Task<Void, Never>?
     private var lastEventID: String?
     public nonisolated let logger: Logger
-
+    
     private var isConnected = false
     private let messageStream: AsyncThrowingStream<Data, Swift.Error>
     private let messageContinuation: AsyncThrowingStream<Data, Swift.Error>.Continuation
-
+    
     public init(
         endpoint: URL,
         configuration: URLSessionConfiguration = .default,
@@ -31,7 +31,7 @@ public actor HTTPClientTransport: Actor, Transport {
             logger: logger
         )
     }
-
+    
     internal init(
         endpoint: URL,
         session: URLSession,
@@ -41,83 +41,98 @@ public actor HTTPClientTransport: Actor, Transport {
         self.endpoint = endpoint
         self.session = session
         self.streaming = streaming
-
+        
         // Create message stream
         var continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation!
         self.messageStream = AsyncThrowingStream { continuation = $0 }
         self.messageContinuation = continuation
-
+        
         self.logger =
-            logger
-            ?? Logger(
-                label: "mcp.transport.http.client",
-                factory: { _ in SwiftLogNoOpLogHandler() }
-            )
+        logger
+        ?? Logger(
+            label: "mcp.transport.http.client",
+            factory: { _ in SwiftLogNoOpLogHandler() }
+        )
     }
-
+        
     /// Establishes connection with the transport
     public func connect() async throws {
-        guard !isConnected else { return }
-        isConnected = true
-
-        if streaming {
-            // Start listening to server events
-            streamingTask = Task { await startListeningForServerEvents() }
+        try await withUnsafeThrowingContinuation { (cont: UnsafeContinuation<Void, Swift.Error>) in
+            guard !isConnected else {
+                cont.resume(throwing: MCPError.internalError("Transport already connected"))
+                return
+            }
+            
+            isConnected = true
+            
+            addListener("endpoint") { endpointPath in
+                guard let resolvedURL = URL(string: endpointPath, relativeTo: self.endpoint)?.absoluteURL else {
+                    cont.resume(throwing: MCPError.internalError("Invalid endpoint URL"))
+                    return
+                }
+                self.endpoint = resolvedURL
+                cont.resume()
+            }
+            
+            if streaming {
+                // Start listening to server events
+                streamingTask = Task { await startListeningForServerEvents() }
+            }
+            
+            logger.info("HTTP transport connected")
         }
-
-        logger.info("HTTP transport connected")
     }
-
+    
     /// Disconnects from the transport
     public func disconnect() async {
         guard isConnected else { return }
         isConnected = false
-
+        
         // Cancel streaming task if active
         streamingTask?.cancel()
         streamingTask = nil
-
+        
         // Cancel any in-progress requests
         session.invalidateAndCancel()
-
+        
         // Clean up message stream
         messageContinuation.finish()
-
+        
         logger.info("HTTP clienttransport disconnected")
     }
-
+    
     /// Sends data through an HTTP POST request
     public func send(_ data: Data) async throws {
         guard isConnected else {
             throw MCPError.internalError("Transport not connected")
         }
-
+        
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.addValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = data
-
+        
         // Add session ID if available
         if let sessionID = sessionID {
             request.addValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
         }
-
+        
         let (responseData, response) = try await session.data(for: request)
-
+        
         guard let httpResponse = response as? HTTPURLResponse else {
             throw MCPError.internalError("Invalid HTTP response")
         }
-
+        
         // Process the response based on content type and status code
         let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type") ?? ""
-
+        
         // Extract session ID if present
         if let newSessionID = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id") {
             self.sessionID = newSessionID
             logger.debug("Session ID received", metadata: ["sessionID": "\(newSessionID)"])
         }
-
+        
         // Handle different response types
         switch httpResponse.statusCode {
         case 200, 201, 202:
@@ -127,7 +142,7 @@ public actor HTTPClientTransport: Actor, Transport {
                 // The streaming is handled by the SSE task if active
                 return
             }
-
+            
             // For JSON responses, deliver the data directly
             if contentType.contains("application/json") && !responseData.isEmpty {
                 logger.debug("Received JSON response", metadata: ["size": "\(responseData.count)"])
@@ -145,18 +160,18 @@ public actor HTTPClientTransport: Actor, Transport {
             throw MCPError.internalError("HTTP error: \(httpResponse.statusCode)")
         }
     }
-
+    
     /// Receives data in an async sequence
     public func receive() -> AsyncThrowingStream<Data, Swift.Error> {
         return messageStream
     }
-
+    
     // MARK: - SSE
-
+    
     /// Starts listening for server events using SSE
     private func startListeningForServerEvents() async {
         guard isConnected else { return }
-
+        
         // Retry loop for connection drops
         while isConnected && !Task.isCancelled {
             do {
@@ -170,143 +185,157 @@ public actor HTTPClientTransport: Actor, Transport {
             }
         }
     }
-
-    #if canImport(FoundationNetworking)
-        private func connectToEventStream() async throws {
-            logger.warning("SSE is not supported on this platform")
+    
+#if canImport(FoundationNetworking)
+    private func connectToEventStream() async throws {
+        logger.warning("SSE is not supported on this platform")
+    }
+#else
+    /// Establishes an SSE connection to the server
+    private func connectToEventStream() async throws {
+        guard isConnected else { return }
+        
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "GET"
+        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
+        
+        // Add session ID if available
+        if let sessionID = sessionID {
+            request.addValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
         }
-    #else
-        /// Establishes an SSE connection to the server
-        private func connectToEventStream() async throws {
-            guard isConnected else { return }
-
-            var request = URLRequest(url: endpoint)
-            request.httpMethod = "GET"
-            request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
-
-            // Add session ID if available
-            if let sessionID = sessionID {
-                request.addValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+        
+        // Add Last-Event-ID header for resumability if available
+        if let lastEventID = lastEventID {
+            request.addValue(lastEventID, forHTTPHeaderField: "Last-Event-ID")
+        }
+        
+        logger.debug("Starting SSE connection")
+        
+        // Create URLSession task for SSE
+        let (stream, response) = try await session.bytes(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw MCPError.internalError("Invalid HTTP response")
+        }
+        
+        // Check response status
+        guard httpResponse.statusCode == 200 else {
+            // If the server returns 405 Method Not Allowed,
+            // it indicates that the server doesn't support SSE streaming.
+            // We should cancel the task instead of retrying the connection.
+            if httpResponse.statusCode == 405 {
+                self.streamingTask?.cancel()
             }
-
-            // Add Last-Event-ID header for resumability if available
-            if let lastEventID = lastEventID {
-                request.addValue(lastEventID, forHTTPHeaderField: "Last-Event-ID")
-            }
-
-            logger.debug("Starting SSE connection")
-
-            // Create URLSession task for SSE
-            let (stream, response) = try await session.bytes(for: request)
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw MCPError.internalError("Invalid HTTP response")
-            }
-
-            // Check response status
-            guard httpResponse.statusCode == 200 else {
-                // If the server returns 405 Method Not Allowed,
-                // it indicates that the server doesn't support SSE streaming.
-                // We should cancel the task instead of retrying the connection.
-                if httpResponse.statusCode == 405 {
-                    self.streamingTask?.cancel()
+            throw MCPError.internalError("HTTP error: \(httpResponse.statusCode)")
+        }
+        
+        // Extract session ID if present
+        if let newSessionID = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id") {
+            self.sessionID = newSessionID
+        }
+        
+        // Process the SSE stream
+        var buffer = ""
+        var eventType = ""
+        var eventID: String?
+        var eventData = ""
+        
+        for try await byte in stream {
+            if Task.isCancelled { break }
+            
+            guard let char = String(bytes: [byte], encoding: .utf8) else { continue }
+            buffer.append(char)
+            
+            // Process complete lines
+            while let newlineIndex = buffer.utf8.firstIndex(where: { $0 == 10 }) {
+                var line = buffer[..<newlineIndex]
+                if line.hasSuffix("\r") {
+                    line = line.dropLast()
                 }
-                throw MCPError.internalError("HTTP error: \(httpResponse.statusCode)")
-            }
-
-            // Extract session ID if present
-            if let newSessionID = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id") {
-                self.sessionID = newSessionID
-            }
-
-            // Process the SSE stream
-            var buffer = ""
-            var eventType = ""
-            var eventID: String?
-            var eventData = ""
-
-            for try await byte in stream {
-                if Task.isCancelled { break }
-
-                guard let char = String(bytes: [byte], encoding: .utf8) else { continue }
-                buffer.append(char)
-
-                // Process complete lines
-                while let newlineIndex = buffer.utf8.firstIndex(where: { $0 == 10 }) {
-                    var line = buffer[..<newlineIndex]
-                    if line.hasSuffix("\r") {
-                        line = line.dropLast()
+                
+                buffer = String(buffer[buffer.index(after: newlineIndex)...])
+                
+                // Empty line marks the end of an event
+                if line.isEmpty {
+                    if !eventData.isEmpty {
+                        // Process the event
+                        if eventType == "id" {
+                            lastEventID = eventID
+                        } else {
+                            // Default event type is "message" if not specified
+                            if let data = eventData.data(using: .utf8) {
+                                logger.debug(
+                                    "SSE event received",
+                                    metadata: [
+                                        "type": "\(eventType.isEmpty ? "message" : eventType)",
+                                        "id": "\(eventID ?? "none")",
+                                    ])
+                                messageContinuation.yield(data)
+                            }
+                        }
+                        listeners[eventType]?(eventData)
+                        
+                        // Reset for next event
+                        eventType = ""
+                        eventData = ""
                     }
-
-                    buffer = String(buffer[buffer.index(after: newlineIndex)...])
-
-                    // Empty line marks the end of an event
-                    if line.isEmpty {
+                    continue
+                }
+                
+                if line.hasSuffix("\r") {
+                    line = line.dropLast()
+                }
+                
+                // Lines starting with ":" are comments
+                if line.hasPrefix(":") { continue }
+                
+                // Parse field: value format
+                if let colonIndex = line.firstIndex(of: ":") {
+                    let field = String(line[..<colonIndex])
+                    var value = String(line[line.index(after: colonIndex)...])
+                    
+                    // Trim leading space
+                    if value.hasPrefix(" ") {
+                        value = String(value.dropFirst())
+                    }
+                    
+                    // Process based on field
+                    switch field {
+                    case "event":
+                        eventType = value
+                    case "data":
                         if !eventData.isEmpty {
-                            // Process the event
-                            if eventType == "id" {
-                                lastEventID = eventID
-                            } else {
-                                // Default event type is "message" if not specified
-                                if let data = eventData.data(using: .utf8) {
-                                    logger.debug(
-                                        "SSE event received",
-                                        metadata: [
-                                            "type": "\(eventType.isEmpty ? "message" : eventType)",
-                                            "id": "\(eventID ?? "none")",
-                                        ])
-                                    messageContinuation.yield(data)
-                                }
-                            }
-
-                            // Reset for next event
-                            eventType = ""
-                            eventData = ""
+                            eventData.append("\n")
                         }
-                        continue
-                    }
-
-                    if line.hasSuffix("\r") {
-                        line = line.dropLast()
-                    }
-
-                    // Lines starting with ":" are comments
-                    if line.hasPrefix(":") { continue }
-
-                    // Parse field: value format
-                    if let colonIndex = line.firstIndex(of: ":") {
-                        let field = String(line[..<colonIndex])
-                        var value = String(line[line.index(after: colonIndex)...])
-
-                        // Trim leading space
-                        if value.hasPrefix(" ") {
-                            value = String(value.dropFirst())
+                        eventData.append(value)
+                    case "id":
+                        if !value.contains("\0") {  // ID must not contain NULL
+                            eventID = value
+                            lastEventID = value
                         }
-
-                        // Process based on field
-                        switch field {
-                        case "event":
-                            eventType = value
-                        case "data":
-                            if !eventData.isEmpty {
-                                eventData.append("\n")
-                            }
-                            eventData.append(value)
-                        case "id":
-                            if !value.contains("\0") {  // ID must not contain NULL
-                                eventID = value
-                                lastEventID = value
-                            }
-                        case "retry":
-                            // Retry timing not implemented
-                            break
-                        default:
-                            // Unknown fields are ignored per SSE spec
-                            break
-                        }
+                    case "retry":
+                        // Retry timing not implemented
+                        break
+                    default:
+                        // Unknown fields are ignored per SSE spec
+                        break
                     }
                 }
             }
         }
-    #endif
+    }
+#endif
+
+    // MARK: - Event Handling
+    
+    typealias EventName = String
+    
+    typealias EventData = String
+    
+    private var listeners = [EventName: (EventData) -> Void]()
+    
+    private func addListener(_ named: EventName, handler: @escaping @isolated(any) (EventData) -> Void) {
+        listeners[named] = handler
+    }
+    
 }


### PR DESCRIPTION
I noticed that endpoint event is not being handled meaning when server responds with tokenized endpoint and client should switch over to it, we were ignoring it previously resulting in client never connecting.

To fix this we need to listen to the endpoint event and update our endpoint with the new tokenizer path, i.e. for deployed cloudflare starter MCP URL switches from https://remote-mcp-server-authless.sash-508.workers.dev/sse to https://remote-mcp-server-authless.sash-508.workers.dev/sse/message?sessionId=031450d4723c2a13a476a68f1d4ab619c279d38937f878c1f1c10c19ef32dfc2

## Motivation and Context
Without it SSE servers fail to connect.
⚠️ it is hard for me to tell if this breaks other flows, i.e. do we always expect endpoint event to arrive before we can consider client connected?
I only found 

## How Has This Been Tested?
Tested against:
* deployed authless server from https://developers.cloudflare.com/agents/guides/remote-mcp-server/ (https://github.com/zats/remote-mcp-server-authless)
* zappier authless mcp https://zapier.com/mcp
* https://apify.com's MCP server e.g. https://apify.com/dtrungtin/imdb-scraper/api/mcp, this one uses token-based authentication which we can achieve by passing authorization header via URLSessionConfiguration

```
let config = URLSessionConfiguration.ephemeral.copy() as! URLSessionConfiguration
config.httpAdditionalHeaders = [
    "Authorization": "Bearer apify_api_xxxxxxxxx"
]
let transport = HTTPClientTransport(
  endpoint: url,
  configuration: config,
  streaming: true,
  logger: logger
)
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
There are a few follow ups needed:
1. For the clients requiring auth, initial connection fails with 401 code, this is currently not handled and we should fallback onto auth provider
