### PR TITLE
Use `EventSource` for SSE implementation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "cce36cb33302c2f1c28458e19b8439f736fc28106e4c6ea95d7992c74594c242",
+  "originHash" : "08de61941b7919a65e36c0e34f8c1c41995469b86a39122158b75b4a68c4527d",
   "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/loopwork-ai/eventsource.git",
+      "state" : {
+        "revision" : "e83f076811f32757305b8bf69ac92d05626ffdd7",
+        "version" : "1.1.0"
+      }
+    },
     {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,25 @@
 
 import PackageDescription
 
+// Base dependencies needed on all platforms
+var dependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/apple/swift-system.git", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+]
+
+// Target dependencies needed on all platforms
+var targetDependencies: [Target.Dependency] = [
+    .product(name: "SystemPackage", package: "swift-system"),
+    .product(name: "Logging", package: "swift-log"),
+]
+
+// Add EventSource only on Apple platforms (non-Linux)
+#if !os(Linux)
+    dependencies.append(
+        .package(url: "https://github.com/loopwork-ai/eventsource.git", from: "1.1.0"))
+    targetDependencies.append(.product(name: "EventSource", package: "eventsource"))
+#endif
+
 let package = Package(
     name: "mcp-swift-sdk",
     platforms: [
@@ -19,28 +38,15 @@ let package = Package(
             name: "MCP",
             targets: ["MCP"])
     ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-system.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
-        .package(url: "https://github.com/loopwork-ai/eventsource.git", from: "1.1.0"),
-    ],
+    dependencies: dependencies,
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "MCP",
-            dependencies: [
-                .product(name: "SystemPackage", package: "swift-system"),
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "EventSource", package: "eventsource"),
-            ]),
+            dependencies: targetDependencies),
         .testTarget(
             name: "MCPTests",
-            dependencies: [
-                "MCP",
-                .product(name: "SystemPackage", package: "swift-system"),
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "EventSource", package: "eventsource"),
-            ]),
+            dependencies: ["MCP"] + targetDependencies),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-system.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+        .package(url: "https://github.com/loopwork-ai/eventsource.git", from: "1.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -31,6 +32,7 @@ let package = Package(
             dependencies: [
                 .product(name: "SystemPackage", package: "swift-system"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "EventSource", package: "eventsource"),
             ]),
         .testTarget(
             name: "MCPTests",
@@ -38,6 +40,7 @@ let package = Package(
                 "MCP",
                 .product(name: "SystemPackage", package: "swift-system"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "EventSource", package: "eventsource"),
             ]),
     ]
 )

--- a/Tests/MCPTests/HTTPClientTransportTests.swift
+++ b/Tests/MCPTests/HTTPClientTransportTests.swift
@@ -341,7 +341,7 @@ import Testing
                     Issue.record("Expected MCPError.internalError, got \(error)")
                     throw error
                 }
-                #expect(message?.contains("Unexpected HTTP response: 500") ?? false)
+                #expect(message?.contains("Server error: 500") ?? false)
             } catch {
                 Issue.record("Expected MCPError, got \(error)")
                 throw error

--- a/Tests/MCPTests/HTTPClientTransportTests.swift
+++ b/Tests/MCPTests/HTTPClientTransportTests.swift
@@ -341,7 +341,7 @@ import Testing
                     Issue.record("Expected MCPError.internalError, got \(error)")
                     throw error
                 }
-                #expect(message?.contains("HTTP error: 500") ?? false)
+                #expect(message?.contains("Unexpected HTTP response: 500") ?? false)
             } catch {
                 Issue.record("Expected MCPError, got \(error)")
                 throw error


### PR DESCRIPTION
This PR updates `HTTPClientTransport` to use the [EventSource](https://github.com/loopwork-ai/EventSource) package for processing server-sent events, replacing the ad hoc implementation with a more exhaustively tested dependency.

This PR also incorporates changes by @stallent in #91, specifically:

- **Handling 405 response for streaming GET requests**: If a server doesn't support streaming from the GET endpoint, it should return a 405. In response, the client cancels the streaming task.
- **Add support for streams coming back from POST requests**: This involves changing `session.data(for: request)` to `session.bytes(for: request)` in the `send` function and adding logic to process the SSE stream or JSON data from the response stream.