### PR TITLE
Update `Client.connect(transport:)` to automatically send `initialize` request

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,9 @@ import MCP
 // Initialize the client
 let client = Client(name: "MyApp", version: "1.0.0")
 
-// Create a transport and connect
+// Create a transport and connect - initialization happens automatically
 let transport = StdioTransport()
-try await client.connect(transport: transport)
-
-// Initialize the connection
-let result = try await client.initialize()
+let result = try await client.connect(transport: transport)
 
 // Check server capabilities
 if result.capabilities.tools != nil {
@@ -74,7 +71,7 @@ For local subprocess communication:
 ```swift
 // Create a stdio transport (simplest option)
 let transport = StdioTransport()
-try await client.connect(transport: transport)
+let result = try await client.connect(transport: transport)
 ```
 
 #### HTTP Transport
@@ -87,7 +84,7 @@ let transport = HTTPClientTransport(
     endpoint: URL(string: "http://localhost:8080")!,
     streaming: true  // Enable Server-Sent Events for real-time updates
 )
-try await client.connect(transport: transport)
+let result = try await client.connect(transport: transport)
 ```
 
 ### Tools

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ if result.capabilities.tools != nil {
 }
 ```
 
+> [!NOTE]
+> The `Client.connect(transport:)` method returns the initialization result.
+> This return value is discardable, 
+> so you can ignore it if you don't need to check server capabilities.
+
 ### Transport Options for Clients
 
 #### Stdio Transport
@@ -71,7 +76,7 @@ For local subprocess communication:
 ```swift
 // Create a stdio transport (simplest option)
 let transport = StdioTransport()
-let result = try await client.connect(transport: transport)
+try await client.connect(transport: transport)
 ```
 
 #### HTTP Transport
@@ -84,7 +89,7 @@ let transport = HTTPClientTransport(
     endpoint: URL(string: "http://localhost:8080")!,
     streaming: true  // Enable Server-Sent Events for real-time updates
 )
-let result = try await client.connect(transport: transport)
+try await client.connect(transport: transport)
 ```
 
 ### Tools
@@ -275,7 +280,7 @@ Handle common client errors:
 
 ```swift
 do {
-    let result = try await client.initialize()
+    try await client.connect()
     // Success
 } catch let error as MCPError {
     print("MCP Error: \(error.localizedDescription)")

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ import MCP
 // Initialize the client
 let client = Client(name: "MyApp", version: "1.0.0")
 
-// Create a transport and connect - initialization happens automatically
+// Create a transport and connect
 let transport = StdioTransport()
 let result = try await client.connect(transport: transport)
 
@@ -404,7 +404,7 @@ The server component allows your application to host model capabilities and resp
 ```swift
 import MCP
 
-// Initialize the server with capabilities
+// Create a server with given capabilities
 let server = Server(
     name: "MyModelServer",
     version: "1.0.0",

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Handle common client errors:
 
 ```swift
 do {
-    try await client.connect()
+    try await client.connect(transport: transport)
     // Success
 } catch let error as MCPError {
     print("MCP Error: \(error.localizedDescription)")

--- a/Sources/MCP/Base/Transports/HTTPClientTransport.swift
+++ b/Sources/MCP/Base/Transports/HTTPClientTransport.swift
@@ -41,9 +41,6 @@ import Logging
 /// let client = Client(name: "MyApp", version: "1.0.0")
 /// try await client.connect(transport: transport)
 ///
-/// // Initialize the connection
-/// let result = try await client.initialize()
-///
 /// // The transport will automatically handle SSE events
 /// // and deliver them through the client's notification handlers
 /// ```

--- a/Sources/MCP/Base/Transports/NetworkTransport.swift
+++ b/Sources/MCP/Base/Transports/NetworkTransport.swift
@@ -51,9 +51,6 @@ import Logging
     /// // Use the transport with an MCP client
     /// let client = Client(name: "MyApp", version: "1.0.0")
     /// try await client.connect(transport: transport)
-    ///
-    /// // Initialize the connection
-    /// let result = try await client.initialize()
     /// ```
     public actor NetworkTransport: Transport {
         /// Represents a heartbeat message for connection health monitoring.

--- a/Sources/MCP/Base/Transports/StdioTransport.swift
+++ b/Sources/MCP/Base/Transports/StdioTransport.swift
@@ -44,9 +44,6 @@ import struct Foundation.Data
     /// // Create a transport and connect
     /// let transport = StdioTransport()
     /// try await client.connect(transport: transport)
-    ///
-    /// // Initialize the connection
-    /// let result = try await client.initialize()
     /// ```
     public actor StdioTransport: Transport {
         private let input: FileDescriptor

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -168,6 +168,7 @@ public actor Client {
     }
 
     /// Connect to the server using the given transport
+    @discardableResult
     public func connect(transport: any Transport) async throws -> Initialize.Result {
         self.connection = transport
         try await self.connection?.connect()

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -168,7 +168,7 @@ public actor Client {
     }
 
     /// Connect to the server using the given transport
-    public func connect(transport: any Transport) async throws {
+    public func connect(transport: any Transport) async throws -> Initialize.Result {
         self.connection = transport
         try await self.connection?.connect()
 
@@ -217,6 +217,10 @@ public actor Client {
             } while true
             await self.logger?.info("Client message handling loop task is terminating.")
         }
+
+        // Automatically initialize after connecting
+        let result = try await initialize()
+        return result
     }
 
     /// Disconnect the client and cancel all pending requests

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -220,8 +220,7 @@ public actor Client {
         }
 
         // Automatically initialize after connecting
-        let result = try await initialize()
-        return result
+        return try await _initialize()
     }
 
     /// Disconnect the client and cancel all pending requests
@@ -485,7 +484,23 @@ public actor Client {
 
     // MARK: - Lifecycle
 
+    /// Initialize the connection with the server.
+    ///
+    /// - Important: This method is deprecated. Initialization now happens automatically
+    ///   when calling `connect(transport:)`. You should use that method instead.
+    ///
+    /// - Returns: The server's initialization response containing capabilities and server info
+    @available(
+        *, deprecated,
+        message:
+            "Initialization now happens automatically during connect. Use connect(transport:) instead."
+    )
     public func initialize() async throws -> Initialize.Result {
+        return try await _initialize()
+    }
+
+    /// Internal initialization implementation
+    private func _initialize() async throws -> Initialize.Result {
         let request = Initialize.request(
             .init(
                 protocolVersion: Version.latest,

--- a/Tests/MCPTests/ClientTests.swift
+++ b/Tests/MCPTests/ClientTests.swift
@@ -11,18 +11,40 @@ struct ClientTests {
         let client = Client(name: "TestClient", version: "1.0")
 
         #expect(await transport.isConnected == false)
+
+        // Set up a task to handle the initialize response
+        let initTask = Task {
+            try await Task.sleep(for: .milliseconds(10))
+            if let lastMessage = await transport.sentMessages.last,
+                let data = lastMessage.data(using: .utf8),
+                let request = try? JSONDecoder().decode(Request<Initialize>.self, from: data)
+            {
+                let response = Initialize.response(
+                    id: request.id,
+                    result: .init(
+                        protocolVersion: Version.latest,
+                        capabilities: .init(),
+                        serverInfo: .init(name: "TestServer", version: "1.0"),
+                        instructions: nil
+                    )
+                )
+                try await transport.queue(response: response)
+            }
+        }
+
         let result = try await client.connect(transport: transport)
         #expect(await transport.isConnected == true)
         #expect(result.protocolVersion == Version.latest)
         await client.disconnect()
         #expect(await transport.isConnected == false)
+        initTask.cancel()
     }
 
     @Test(
-        "Initialize request",
+        "Ping request",
         .timeLimit(.minutes(1))
     )
-    func testClientInitialize() async throws {
+    func testClientPing() async throws {
         let transport = MockTransport()
         let client = Client(name: "TestClient", version: "1.0")
 
@@ -51,38 +73,24 @@ struct ClientTests {
             #expect(result.protocolVersion == Version.latest)
             #expect(result.serverInfo.name == "TestServer")
             #expect(result.serverInfo.version == "1.0")
+
+            // Small delay to ensure message loop is started
+            try await Task.sleep(for: .milliseconds(10))
+
+            // Create a task for the ping
+            let pingTask = Task {
+                try await client.ping()
+            }
+
+            // Give it a moment to send the request
+            try await Task.sleep(for: .milliseconds(10))
+
+            #expect(await transport.sentMessages.count == 2)  // Initialize + Ping
+            #expect(await transport.sentMessages.last?.contains(Ping.name) == true)
+
+            // Cancel the ping task
+            pingTask.cancel()
         }
-
-        // Disconnect client to clean up message loop and give time for continuation cleanup
-        await client.disconnect()
-        try await Task.sleep(for: .milliseconds(50))
-    }
-
-    @Test(
-        "Ping request",
-        .timeLimit(.minutes(1))
-    )
-    func testClientPing() async throws {
-        let transport = MockTransport()
-        let client = Client(name: "TestClient", version: "1.0")
-
-        try await client.connect(transport: transport)
-        // Small delay to ensure message loop is started
-        try await Task.sleep(for: .milliseconds(10))
-
-        // Create a task for the ping that we'll cancel
-        let pingTask = Task {
-            try await client.ping()
-        }
-
-        // Give it a moment to send the request
-        try await Task.sleep(for: .milliseconds(10))
-
-        #expect(await transport.sentMessages.count == 1)
-        #expect(await transport.sentMessages.first?.contains(Ping.name) == true)
-
-        // Cancel the ping task
-        pingTask.cancel()
 
         // Disconnect client to clean up message loop and give time for continuation cleanup
         await client.disconnect()
@@ -112,10 +120,35 @@ struct ClientTests {
     @Test("Send failure handling")
     func testClientSendFailure() async throws {
         let transport = MockTransport()
-        await transport.setFailSend(true)
         let client = Client(name: "TestClient", version: "1.0")
 
+        // Set up a task to handle the initialize response
+        let initTask = Task {
+            try await Task.sleep(for: .milliseconds(10))
+            if let lastMessage = await transport.sentMessages.last,
+                let data = lastMessage.data(using: .utf8),
+                let request = try? JSONDecoder().decode(Request<Initialize>.self, from: data)
+            {
+                let response = Initialize.response(
+                    id: request.id,
+                    result: .init(
+                        protocolVersion: Version.latest,
+                        capabilities: .init(),
+                        serverInfo: .init(name: "TestServer", version: "1.0"),
+                        instructions: nil
+                    )
+                )
+                try await transport.queue(response: response)
+            }
+        }
+
+        // Connect first without failure
         try await client.connect(transport: transport)
+        try await Task.sleep(for: .milliseconds(10))
+        initTask.cancel()
+
+        // Now set the transport to fail sends
+        await transport.setFailSend(true)
 
         do {
             try await client.ping()
@@ -124,11 +157,13 @@ struct ClientTests {
             if case MCPError.transportError = error {
                 #expect(Bool(true))
             } else {
-                #expect(Bool(false), "Expected transport error")
+                #expect(Bool(false), "Expected transport error, got \(error)")
             }
         } catch {
             #expect(Bool(false), "Expected MCP.Error")
         }
+
+        await client.disconnect()
     }
 
     @Test("Strict configuration - capabilities check")
@@ -136,6 +171,26 @@ struct ClientTests {
         let transport = MockTransport()
         let config = Client.Configuration.strict
         let client = Client(name: "TestClient", version: "1.0", configuration: config)
+
+        // Set up a task to handle the initialize response
+        let initTask = Task {
+            try await Task.sleep(for: .milliseconds(10))
+            if let lastMessage = await transport.sentMessages.last,
+                let data = lastMessage.data(using: .utf8),
+                let request = try? JSONDecoder().decode(Request<Initialize>.self, from: data)
+            {
+                let response = Initialize.response(
+                    id: request.id,
+                    result: .init(
+                        protocolVersion: Version.latest,
+                        capabilities: .init(),
+                        serverInfo: .init(name: "TestServer", version: "1.0"),
+                        instructions: nil
+                    )
+                )
+                try await transport.queue(response: response)
+            }
+        }
 
         try await client.connect(transport: transport)
 
@@ -160,6 +215,7 @@ struct ClientTests {
 
         // Cancel the task if it's still running
         promptsTask.cancel()
+        initTask.cancel()
 
         // Disconnect client
         await client.disconnect()
@@ -172,7 +228,30 @@ struct ClientTests {
         let config = Client.Configuration.default
         let client = Client(name: "TestClient", version: "1.0", configuration: config)
 
+        // Set up a task to handle the initialize response
+        let initTask = Task {
+            try await Task.sleep(for: .milliseconds(10))
+            if let lastMessage = await transport.sentMessages.last,
+                let data = lastMessage.data(using: .utf8),
+                let request = try? JSONDecoder().decode(Request<Initialize>.self, from: data)
+            {
+                let response = Initialize.response(
+                    id: request.id,
+                    result: .init(
+                        protocolVersion: Version.latest,
+                        capabilities: .init(),
+                        serverInfo: .init(name: "TestServer", version: "1.0"),
+                        instructions: nil
+                    )
+                )
+                try await transport.queue(response: response)
+            }
+        }
+
         try await client.connect(transport: transport)
+
+        // Make sure init task is complete
+        initTask.cancel()
 
         // Wait a bit for any setup to complete
         try await Task.sleep(for: .milliseconds(10))
@@ -240,8 +319,29 @@ struct ClientTests {
         let transport = MockTransport()
         let client = Client(name: "TestClient", version: "1.0")
 
+        // Set up a task to handle the initialize response
+        let initTask = Task {
+            try await Task.sleep(for: .milliseconds(10))
+            if let lastMessage = await transport.sentMessages.last,
+                let data = lastMessage.data(using: .utf8),
+                let request = try? JSONDecoder().decode(Request<Initialize>.self, from: data)
+            {
+                let response = Initialize.response(
+                    id: request.id,
+                    result: .init(
+                        protocolVersion: Version.latest,
+                        capabilities: .init(),
+                        serverInfo: .init(name: "TestServer", version: "1.0"),
+                        instructions: nil
+                    )
+                )
+                try await transport.queue(response: response)
+            }
+        }
+
         try await client.connect(transport: transport)
         try await Task.sleep(for: .milliseconds(10))  // Allow connection tasks
+        initTask.cancel()
 
         let request1 = Ping.request()
         let request2 = Ping.request()
@@ -253,11 +353,11 @@ struct ClientTests {
             resultTask2 = try await batch.addRequest(request2)
         }
 
-        // Check if one batch message was sent
+        // Check if batch message was sent (after initialize and initialized notification)
         let sentMessages = await transport.sentMessages
-        #expect(sentMessages.count == 1)
+        #expect(sentMessages.count == 3)  // Initialize request + Initialized notification + Batch
 
-        guard let batchData = sentMessages.first?.data(using: .utf8) else {
+        guard let batchData = sentMessages.last?.data(using: .utf8) else {
             #expect(Bool(false), "Failed to get batch data")
             return
         }
@@ -299,8 +399,29 @@ struct ClientTests {
         let transport = MockTransport()
         let client = Client(name: "TestClient", version: "1.0")
 
+        // Set up a task to handle the initialize response
+        let initTask = Task {
+            try await Task.sleep(for: .milliseconds(10))
+            if let lastMessage = await transport.sentMessages.last,
+                let data = lastMessage.data(using: .utf8),
+                let request = try? JSONDecoder().decode(Request<Initialize>.self, from: data)
+            {
+                let response = Initialize.response(
+                    id: request.id,
+                    result: .init(
+                        protocolVersion: Version.latest,
+                        capabilities: .init(),
+                        serverInfo: .init(name: "TestServer", version: "1.0"),
+                        instructions: nil
+                    )
+                )
+                try await transport.queue(response: response)
+            }
+        }
+
         try await client.connect(transport: transport)
         try await Task.sleep(for: .milliseconds(10))
+        initTask.cancel()
 
         let request1 = Ping.request()  // Success
         let request2 = Ping.request()  // Error
@@ -312,8 +433,8 @@ struct ClientTests {
             resultTasks.append(try await batch.addRequest(request2))
         }
 
-        // Check if one batch message was sent
-        #expect(await transport.sentMessages.count == 1)
+        // Check if batch message was sent (after initialize and initialized notification)
+        #expect(await transport.sentMessages.count == 3)  // Initialize request + Initialized notification + Batch
 
         // Prepare batch response (success for 1, error for 2)
         let response1 = Response<Ping>(id: request1.id, result: .init())
@@ -358,16 +479,37 @@ struct ClientTests {
         let transport = MockTransport()
         let client = Client(name: "TestClient", version: "1.0")
 
+        // Set up a task to handle the initialize response
+        let initTask = Task {
+            try await Task.sleep(for: .milliseconds(10))
+            if let lastMessage = await transport.sentMessages.last,
+                let data = lastMessage.data(using: .utf8),
+                let request = try? JSONDecoder().decode(Request<Initialize>.self, from: data)
+            {
+                let response = Initialize.response(
+                    id: request.id,
+                    result: .init(
+                        protocolVersion: Version.latest,
+                        capabilities: .init(),
+                        serverInfo: .init(name: "TestServer", version: "1.0"),
+                        instructions: nil
+                    )
+                )
+                try await transport.queue(response: response)
+            }
+        }
+
         try await client.connect(transport: transport)
         try await Task.sleep(for: .milliseconds(10))
+        initTask.cancel()
 
         // Call withBatch but don't add any requests
         try await client.withBatch { _ in
             // No requests added
         }
 
-        // Check that no messages were sent
-        #expect(await transport.sentMessages.isEmpty)
+        // Check that only initialize message and initialized notification were sent
+        #expect(await transport.sentMessages.count == 2)  // Initialize request + Initialized notification
 
         await client.disconnect()
     }
@@ -377,17 +519,38 @@ struct ClientTests {
         let transport = MockTransport()
         let client = Client(name: "TestClient", version: "1.0")
 
+        // Set up a task to handle the initialize response
+        let initTask = Task {
+            try await Task.sleep(for: .milliseconds(10))
+            if let lastMessage = await transport.sentMessages.last,
+                let data = lastMessage.data(using: .utf8),
+                let request = try? JSONDecoder().decode(Request<Initialize>.self, from: data)
+            {
+                let response = Initialize.response(
+                    id: request.id,
+                    result: .init(
+                        protocolVersion: Version.latest,
+                        capabilities: .init(),
+                        serverInfo: .init(name: "TestServer", version: "1.0"),
+                        instructions: nil
+                    )
+                )
+                try await transport.queue(response: response)
+            }
+        }
+
         try await client.connect(transport: transport)
         try await Task.sleep(for: .milliseconds(10))
+        initTask.cancel()
 
         // Create a test notification
         let notification = InitializedNotification.message()
         try await client.notify(notification)
 
-        // Verify notification was sent
-        #expect(await transport.sentMessages.count == 1)
+        // Verify notification was sent (in addition to initialize and initialized notification)
+        #expect(await transport.sentMessages.count == 3)  // Initialize request + Initialized notification + Custom notification
 
-        if let sentMessage = await transport.sentMessages.first,
+        if let sentMessage = await transport.sentMessages.last,
             let data = sentMessage.data(using: .utf8)
         {
 
@@ -411,9 +574,6 @@ struct ClientTests {
     func testClientInitializeNotification() async throws {
         let transport = MockTransport()
         let client = Client(name: "TestClient", version: "1.0")
-
-        try await client.connect(transport: transport)
-        try await Task.sleep(for: .milliseconds(10))
 
         // Create a task for initialize
         let initTask = Task {
@@ -439,7 +599,8 @@ struct ClientTests {
                 try await transport.queue(response: response)
 
                 // Now complete the initialize call
-                _ = try await client.initialize()
+                try await client.connect(transport: transport)
+                try await Task.sleep(for: .milliseconds(10))
 
                 // Verify that two messages were sent: initialize request and initialized notification
                 #expect(await transport.sentMessages.count == 2)

--- a/Tests/MCPTests/ClientTests.swift
+++ b/Tests/MCPTests/ClientTests.swift
@@ -654,8 +654,29 @@ struct ClientTests {
         let transport = MockTransport()
         let client = Client(name: "TestClient", version: "1.0")
 
+        // Set up a task to handle the initialize response
+        let initTask = Task {
+            try await Task.sleep(for: .milliseconds(10))
+            if let lastMessage = await transport.sentMessages.last,
+                let data = lastMessage.data(using: .utf8),
+                let request = try? JSONDecoder().decode(Request<Initialize>.self, from: data)
+            {
+                let response = Initialize.response(
+                    id: request.id,
+                    result: .init(
+                        protocolVersion: Version.latest,
+                        capabilities: .init(),
+                        serverInfo: .init(name: "TestServer", version: "1.0"),
+                        instructions: nil
+                    )
+                )
+                try await transport.queue(response: response)
+            }
+        }
+
         try await client.connect(transport: transport)
         try await Task.sleep(for: .milliseconds(10))
+        initTask.cancel()
 
         // Set up the transport to fail sends from the start
         await transport.setFailSend(true)
@@ -694,8 +715,29 @@ struct ClientTests {
         let transport = MockTransport()
         let client = Client(name: "TestClient", version: "1.0")
 
+        // Set up a task to handle the initialize response
+        let initTask = Task {
+            try await Task.sleep(for: .milliseconds(10))
+            if let lastMessage = await transport.sentMessages.last,
+                let data = lastMessage.data(using: .utf8),
+                let request = try? JSONDecoder().decode(Request<Initialize>.self, from: data)
+            {
+                let response = Initialize.response(
+                    id: request.id,
+                    result: .init(
+                        protocolVersion: Version.latest,
+                        capabilities: .init(),
+                        serverInfo: .init(name: "TestServer", version: "1.0"),
+                        instructions: nil
+                    )
+                )
+                try await transport.queue(response: response)
+            }
+        }
+
         try await client.connect(transport: transport)
         try await Task.sleep(for: .milliseconds(10))
+        initTask.cancel()
 
         // Create a ping request to get the ID
         let request = Ping.request()

--- a/Tests/MCPTests/HTTPClientTransportTests.swift
+++ b/Tests/MCPTests/HTTPClientTransportTests.swift
@@ -653,11 +653,8 @@ import Testing
                 }
             }
 
-            // Execute the complete flow
-            try await client.connect(transport: transport)
-
             // Step 1: Initialize client
-            let initResult = try await client.initialize()
+            let initResult = try await client.connect(transport: transport)
             #expect(initResult.protocolVersion == Version.latest)
             #expect(initResult.capabilities.tools != nil)
 

--- a/Tests/MCPTests/RoundtripTests.swift
+++ b/Tests/MCPTests/RoundtripTests.swift
@@ -99,10 +99,9 @@ struct RoundtripTests {
         let client = Client(name: "TestClient", version: "1.0")
 
         try await server.start(transport: serverTransport)
-        try await client.connect(transport: clientTransport)
 
         let initTask = Task {
-            let result = try await client.initialize()
+            let result = try await client.connect(transport: clientTransport)
 
             #expect(result.serverInfo.name == "TestServer")
             #expect(result.serverInfo.version == "1.0.0")

--- a/Tests/MCPTests/SamplingTests.swift
+++ b/Tests/MCPTests/SamplingTests.swift
@@ -380,30 +380,6 @@ struct SamplingIntegrationTests {
         try await server.start(transport: serverTransport)
         try await client.connect(transport: clientTransport)
 
-        // Test initialization and capability negotiation
-        let initTask = Task {
-            let result = try await client.initialize()
-
-            #expect(result.serverInfo.name == "SamplingTestServer")
-            #expect(result.serverInfo.version == "1.0.0")
-            #expect(
-                result.capabilities.sampling != nil, "Server should advertise sampling capability")
-            #expect(result.protocolVersion == Version.latest)
-        }
-
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
-                try await Task.sleep(for: .seconds(1))
-                initTask.cancel()
-                throw CancellationError()
-            }
-            group.addTask {
-                try await initTask.value
-            }
-            try await group.next()
-            group.cancelAll()
-        }
-
         await server.stop()
         await client.disconnect()
         try? clientToServerRead.close()


### PR DESCRIPTION
See https://github.com/modelcontextprotocol/swift-sdk/pull/97#issuecomment-2854841741

Other SDKs have clients automatically send `initialize` message when connecting to a server. This PR updates our implementation to do the same. Beyond consistency, this helps mitigate an invisible time dependency / race condition for clients with streamable HTTP transport, as the client waits for a session ID before subscribing to SSE events. If the API consumer failed to call `initialize` immediately after connecting, this could result in SSE subscriptions timing out.

This PR deprecates the existing `Client.initialize` method. This method will be removed in a future version (or more accurately, it will be made `private` and replace the current `private func _initialize` method).