### PR TITLE
Don't throw error if there's a protocol mismatch between client and server

### DIFF
--- a/Sources/MCP/Server/Server.swift
+++ b/Sources/MCP/Server/Server.swift
@@ -337,7 +337,8 @@ public actor Server {
             } catch {
                 // Only add errors to response for requests (notifications don't have responses)
                 if case .request(let request) = item {
-                    let mcpError = error as? MCPError ?? MCPError.internalError(error.localizedDescription)
+                    let mcpError =
+                        error as? MCPError ?? MCPError.internalError(error.localizedDescription)
                     responses.append(AnyMethod.response(id: request.id, error: mcpError))
                 }
             }
@@ -365,7 +366,9 @@ public actor Server {
     ///   - request: The request to handle
     ///   - sendResponse: Whether to send the response immediately (true) or return it (false)
     /// - Returns: The response when sendResponse is false
-    private func handleRequest(_ request: Request<AnyMethod>, sendResponse: Bool = true) async throws -> Response<AnyMethod>? {
+    private func handleRequest(_ request: Request<AnyMethod>, sendResponse: Bool = true)
+        async throws -> Response<AnyMethod>?
+    {
         // Check if this is a pre-processed error request (empty method)
         if request.method.isEmpty && !sendResponse {
             // This is a placeholder for an invalid request that couldn't be parsed in batch mode
@@ -476,12 +479,6 @@ public actor Server {
 
             guard await !self.isInitialized else {
                 throw MCPError.invalidRequest("Server is already initialized")
-            }
-
-            // Validate protocol version
-            guard Version.latest == params.protocolVersion else {
-                throw MCPError.invalidRequest(
-                    "Unsupported protocol version: \(params.protocolVersion)")
             }
 
             // Call initialization hook if registered


### PR DESCRIPTION
Follow up to #80 

Currently, if a client using a different protocol version (say, 2024-11-05) attempts to connect to a server supporting the latest, the server throws an error in the `initialize` method handler.

This behavior isn't particularly helpful, so this PR removes it.

There may be an argument for making this part of "strict" mode behavior, but we can revisit that in a follow-up.