### PR TITLE
Revert "Remove deprecated `MCP.Error` typealias"

### DIFF
--- a/Sources/MCP/Base/Error.swift
+++ b/Sources/MCP/Base/Error.swift
@@ -243,3 +243,12 @@ extension MCPError: Hashable {
         }
     }
 }
+
+// MARK: -
+
+/// This is provided to allow existing code that uses `MCP.Error` to continue
+/// to work without modification.
+///
+/// The MCPError type is now the recommended way to handle errors in MCP.
+@available(*, deprecated, renamed: "MCPError", message: "Use MCPError instead of MCP.Error")
+public typealias Error = MCPError


### PR DESCRIPTION
Reverts modelcontextprotocol/swift-sdk#102

To be merged back in after cutting a patch release with #103. Removing a deprecated symbol is a pre-1.0 minor change in SemVer, and I'd like to have a bug fix release before cutting 0.9.0.