### PR TITLE
Append handlers in-situ.

### DIFF
--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -244,8 +244,7 @@ public actor Client {
         _ type: N.Type,
         handler: @escaping @Sendable (Message<N>) async throws -> Void
     ) async -> Self {
-        let handlers = notificationHandlers[N.name, default: []]
-        notificationHandlers[N.name] = handlers + [TypedNotificationHandler(handler)]
+        notificationHandlers[N.name, default: []].append(TypedNotificationHandler(handler))
         return self
     }
 

--- a/Sources/MCP/Server/Server.swift
+++ b/Sources/MCP/Server/Server.swift
@@ -257,8 +257,7 @@ public actor Server {
         _ type: N.Type,
         handler: @escaping @Sendable (Message<N>) async throws -> Void
     ) -> Self {
-        let handlers = notificationHandlers[N.name, default: []]
-        notificationHandlers[N.name] = handlers + [TypedNotificationHandler(handler)]
+        notificationHandlers[N.name, default: []].append(TypedNotificationHandler(handler))
         return self
     }
 


### PR DESCRIPTION
While starting to read the code I noticed some code like this:

```swift
let oldValue = someDictionary[key, default:[]]
someDictionary[key] = oldValue + [valueToAppend]
```

I changed those sites to look like this:

// updated
someDictionary[key, default: []].append(valueToAppend)
```

## Motivation and Context

The updated code *may sometimes* perform an in-situ append on the underlying storage; the original would *always* construct a new array. 

In a worst-case scenario the original code could exhibit accidentally-quadratic behavior while, say, registering a large number of "handlers".

## How Has This Been Tested?

I re-ran the unit tests and they still passed. 

I also ran this test to double-check that the setter for `subscript(key:default:)` existed and worked as I thought:

```swift
@Test("In-Place Default Append Works")
func testInPlaceDefaultAppend() {
  var inSituAppend: [String: [Int]] = [:]
  var copyThenOverwrite: [String: [Int]] = [:]
  for value in 1...10 {
    for key in ["foo", "bar", "baz"] {
      inSituAppend[key, default: []].append(value)
      let oldValue = copyThenOverwrite[key, default: []]
      #expect(inSituAppend != copyThenOverwrite)
      copyThenOverwrite[key] = oldValue + [value]
      #expect(inSituAppend == copyThenOverwrite)
    }
  }
}
```

I didn't include that test in the PR because it's a one-off experiment to re-confirm my understanding of a standard-library method, but I'm happy to put it back in if you'd like.

## Breaking Changes

No.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Glad there's an official sdk!