### PR TITLE
adds listResourceTemplates to client 

### DIFF
--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -578,6 +578,13 @@ public actor Client {
         _ = try await send(request)
     }
 
+    public func listResourceTemplates() async throws -> [Resource.Template] {
+        try validateServerCapability(\.resources, "Resources")
+        let request = ListResourceTemplates.request(.init())
+        let result = try await send(request)
+        return result.templates
+    }
+
     // MARK: - Tools
 
     public func listTools(cursor: String? = nil) async throws -> (


### PR DESCRIPTION
Listing resource templates is currently supported by the server but not the client. This adds a method to the client. 

#124 

<img width="1325" alt="image" src="https://github.com/user-attachments/assets/4e839802-1ef0-4b53-a81d-3d6a1ce80848" />
