### PR TITLE
remove info level logging message and use debug instead

### DIFF
--- a/Sources/MCP/Base/Transports/HTTPClientTransport.swift
+++ b/Sources/MCP/Base/Transports/HTTPClientTransport.swift
@@ -152,7 +152,7 @@ public actor HTTPClientTransport: Transport {
             streamingTask = Task { await startListeningForServerEvents() }
         }
 
-        logger.info("HTTP transport connected")
+        logger.debug("HTTP transport connected")
     }
 
     /// Disconnects from the transport
@@ -180,7 +180,7 @@ public actor HTTPClientTransport: Transport {
         initialSessionIDContinuation?.resume()
         initialSessionIDContinuation = nil
 
-        logger.info("HTTP clienttransport disconnected")
+        logger.debug("HTTP clienttransport disconnected")
     }
 
     /// Sends data through an HTTP POST request
@@ -440,7 +440,7 @@ public actor HTTPClientTransport: Transport {
                     "Initial sessionID already available. Proceeding with SSE streaming task immediately."
                 )
             } else {
-                logger.info(
+                logger.trace(
                     "Proceeding with SSE connection attempt; sessionID is nil. This might be expected for stateless servers or if initialize hasn't provided one yet."
                 )
             }

--- a/Sources/MCP/Base/Transports/NetworkTransport.swift
+++ b/Sources/MCP/Base/Transports/NetworkTransport.swift
@@ -336,7 +336,7 @@ import Logging
 
                 // Reset reconnect attempt counter on successful connection
                 reconnectAttempt = 0
-                logger.info("Network transport connected successfully")
+                logger.debug("Network transport connected successfully")
                 continuation.resume()
 
                 // Start the receive loop after connection is established
@@ -466,7 +466,7 @@ import Logging
             {
                 // Try to reconnect with exponential backoff
                 reconnectAttempt += 1
-                logger.info(
+                logger.debug(
                     "Attempting reconnection after \(context) (\(reconnectAttempt)/\(reconnectionConfig.maxAttempts))..."
                 )
 
@@ -509,7 +509,7 @@ import Logging
 
             connection.cancel()
             messageContinuation.finish()
-            logger.info("Network transport disconnected")
+            logger.debug("Network transport disconnected")
         }
 
         /// Sends data through the network connection
@@ -626,7 +626,7 @@ import Logging
 
                             // Check connection state
                             if connection.state != .ready {
-                                logger.info("Connection no longer ready, exiting receive loop")
+                                logger.warning("Connection no longer ready, exiting receive loop")
                                 break
                             }
                         }
@@ -676,7 +676,7 @@ import Logging
                                 && reconnectAttempt < reconnectionConfig.maxAttempts
                             {
                                 reconnectAttempt += 1
-                                logger.info(
+                                logger.warning(
                                     "Network connection lost, attempting reconnection (\(reconnectAttempt)/\(reconnectionConfig.maxAttempts))..."
                                 )
 
@@ -727,7 +727,7 @@ import Logging
                         {
                             // Similar reconnection logic for other errors
                             reconnectAttempt += 1
-                            logger.info(
+                            logger.warning(
                                 "Error during receive, attempting reconnection (\(reconnectAttempt)/\(reconnectionConfig.maxAttempts))..."
                             )
 

--- a/Sources/MCP/Base/Transports/StdioTransport.swift
+++ b/Sources/MCP/Base/Transports/StdioTransport.swift
@@ -94,7 +94,7 @@ import struct Foundation.Data
             try setNonBlocking(fileDescriptor: output)
 
             isConnected = true
-            logger.info("Transport connected successfully")
+            logger.debug("Transport connected successfully")
 
             // Start reading loop in background
             Task {
@@ -181,7 +181,7 @@ import struct Foundation.Data
             guard isConnected else { return }
             isConnected = false
             messageContinuation.finish()
-            logger.info("Transport disconnected")
+            logger.debug("Transport disconnected")
         }
 
         /// Sends a message over the transport.

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -173,7 +173,7 @@ public actor Client {
         self.connection = transport
         try await self.connection?.connect()
 
-        await logger?.info(
+        await logger?.debug(
             "Client connected", metadata: ["name": "\(name)", "version": "\(version)"])
 
         // Start message handling loop
@@ -216,7 +216,7 @@ public actor Client {
                     break
                 }
             } while true
-            await self.logger?.info("Client message handling loop task is terminating.")
+            await self.logger?.debug("Client message handling loop task is terminating.")
         }
 
         // Automatically initialize after connecting
@@ -225,7 +225,7 @@ public actor Client {
 
     /// Disconnect the client and cancel all pending requests
     public func disconnect() async {
-        await logger?.info("Initiating client disconnect...")
+        await logger?.debug("Initiating client disconnect...")
 
         // Part 1: Inside actor - Grab state and clear internal references
         let taskToCancel = self.task
@@ -242,26 +242,26 @@ public actor Client {
         for (_, request) in pendingRequestsToCancel {
             request.resume(throwing: MCPError.internalError("Client disconnected"))
         }
-        await logger?.info("Pending requests cancelled.")
+        await logger?.debug("Pending requests cancelled.")
 
         // Cancel the task
         taskToCancel?.cancel()
-        await logger?.info("Message loop task cancellation requested.")
+        await logger?.debug("Message loop task cancellation requested.")
 
         // Disconnect the transport *before* awaiting the task
         // This should ensure the transport stream is finished, unblocking the loop.
         if let conn = connectionToDisconnect {
             await conn.disconnect()
-            await logger?.info("Transport disconnected.")
+            await logger?.debug("Transport disconnected.")
         } else {
-            await logger?.info("No active transport connection to disconnect.")
+            await logger?.debug("No active transport connection to disconnect.")
         }
 
         // Await the task completion *after* transport disconnect
         _ = await taskToCancel?.value
-        await logger?.info("Client message loop task finished.")
+        await logger?.debug("Client message loop task finished.")
 
-        await logger?.info("Client disconnect complete.")
+        await logger?.debug("Client disconnect complete.")
     }
 
     // MARK: - Registration
@@ -468,7 +468,7 @@ public actor Client {
 
         // Check if there are any requests to send
         guard !requests.isEmpty else {
-            await logger?.info("Batch requested but no requests were added.")
+            await logger?.debug("Batch requested but no requests were added.")
             return  // Nothing to send
         }
 

--- a/Sources/MCP/Server/Server.swift
+++ b/Sources/MCP/Server/Server.swift
@@ -174,7 +174,7 @@ public actor Server {
         registerDefaultHandlers(initializeHook: initializeHook)
         try await transport.connect()
 
-        await logger?.info(
+        await logger?.debug(
             "Server started", metadata: ["name": "\(name)", "version": "\(version)"])
 
         // Start message handling loop
@@ -227,7 +227,7 @@ public actor Server {
                 await logger?.error(
                     "Fatal error in message handling loop", metadata: ["error": "\(error)"])
             }
-            await logger?.info("Server finished", metadata: [:])
+            await logger?.debug("Server finished", metadata: [:])
         }
     }
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

remove `info`-level log messages

## Motivation and Context
Best practices for libraries is to use `debug` and `trace` only to let the developer (user of the library) to choose the verbosity level they provide to their customers

## How Has This Been Tested?
n/a

## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
https://www.swift.org/documentation/server/guides/libraries/log-levels.html