### PR TITLE
Replace compile-time directives with target platform conditions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,20 +7,15 @@ import PackageDescription
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-system.git", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+    .package(url: "https://github.com/loopwork-ai/eventsource.git", from: "1.1.0")
 ]
 
 // Target dependencies needed on all platforms
 var targetDependencies: [Target.Dependency] = [
     .product(name: "SystemPackage", package: "swift-system"),
     .product(name: "Logging", package: "swift-log"),
+    .product(name: "EventSource", package: "eventsource", condition: .when(platforms: [.macOS, .iOS, .tvOS, .visionOS, .watchOS]))
 ]
-
-// Add EventSource only on Apple platforms (non-Linux)
-#if !os(Linux)
-    dependencies.append(
-        .package(url: "https://github.com/loopwork-ai/eventsource.git", from: "1.1.0"))
-    targetDependencies.append(.product(name: "EventSource", package: "eventsource"))
-#endif
 
 let package = Package(
     name: "mcp-swift-sdk",


### PR DESCRIPTION
## Summary
- Replace compile-time `#if \!os(Linux)` directives with Swift Package Manager's native target platform conditions
- Use `.when(platforms: [...])` condition for EventSource dependency instead of compile-time checks
- Leverages SPM's built-in dependency support for platform-specific targets at runtime

## Benefits
- Eliminates need for compile-time directives
- Uses Swift Package Manager's native platform condition support
- Cleaner and more maintainable Package.swift configuration
- Runtime platform detection instead of compile-time preprocessing

## Test plan
- [ ] Verify package builds successfully on all supported platforms
- [ ] Confirm EventSource dependency is only linked on Apple platforms
- [ ] Test that Linux builds continue to work without EventSource

🤖 Generated with [Claude Code](https://claude.ai/code)