### PR TITLE
Add plumbing to set instructions on Server

### DIFF
--- a/Sources/MCP/Server/Server.swift
+++ b/Sources/MCP/Server/Server.swift
@@ -128,10 +128,13 @@ public actor Server {
     public nonisolated var name: String { serverInfo.name }
     /// The server version
     public nonisolated var version: String { serverInfo.version }
+    /// Overall instructions about this server and what it offers to provide to the client
+    public nonisolated let instructions: String?
     /// The server capabilities
     public var capabilities: Capabilities
     /// The server configuration
     public var configuration: Configuration
+    
 
     /// Request handlers
     private var methodHandlers: [String: RequestHandlerBox] = [:]
@@ -154,12 +157,14 @@ public actor Server {
     public init(
         name: String,
         version: String,
+        instructions: String? = nil,
         capabilities: Server.Capabilities = .init(),
         configuration: Configuration = .default
     ) {
         self.serverInfo = Server.Info(name: name, version: version)
         self.capabilities = capabilities
         self.configuration = configuration
+        self.instructions = instructions
     }
 
     /// Start the server
@@ -574,7 +579,7 @@ public actor Server {
                 protocolVersion: negotiatedProtocolVersion,
                 capabilities: await self.capabilities,
                 serverInfo: self.serverInfo,
-                instructions: nil
+                instructions: self.instructions
             )
         }
 

--- a/Sources/MCP/Server/Server.swift
+++ b/Sources/MCP/Server/Server.swift
@@ -128,7 +128,12 @@ public actor Server {
     public nonisolated var name: String { serverInfo.name }
     /// The server version
     public nonisolated var version: String { serverInfo.version }
-    /// Overall instructions about this server and what it offers to provide to the client
+    /// Instructions describing how to use the server and its features
+    ///
+    /// This can be used by clients to improve the LLM's understanding of 
+    /// available tools, resources, etc. 
+    /// It can be thought of like a "hint" to the model. 
+    /// For example, this information MAY be added to the system prompt.
     public nonisolated let instructions: String?
     /// The server capabilities
     public var capabilities: Capabilities


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Added plumbing to allow setting Server level instructions and have it returned in the initialize result. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Allows for higher level instructions and context to be given about the server rather then just individual tools. For instance describing what the tools do and how they should be used.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes, i tested this with Windsurf, for a MCP i'm developing. I checked it could see the instructions by asking it to summarize them. In addition I checked when Cascade was given a higher level instruction it invoked the tools in order as described in the Server instructions.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No. Instructions defaults to nil in the Server initialization which means by default it will perform the same as the previous code.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ N/A] I have added appropriate error handling
- [ N/A] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
