### PR TITLE
fix: allow description field to be absent from `Tool`

### DIFF
--- a/Sources/MCP/Server/Tools.swift
+++ b/Sources/MCP/Server/Tools.swift
@@ -182,7 +182,7 @@ public struct Tool: Hashable, Codable, Sendable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
-        description = try container.decode(String.self, forKey: .description)
+        description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
         inputSchema = try container.decode(Value.self, forKey: .inputSchema)
         annotations =
             try container.decodeIfPresent(Tool.Annotations.self, forKey: .annotations) ?? .init()

--- a/Sources/MCP/Server/Tools.swift
+++ b/Sources/MCP/Server/Tools.swift
@@ -182,7 +182,7 @@ public struct Tool: Hashable, Codable, Sendable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
-        description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
+        description = try container.decodeIfPresent(String.self, forKey: .description)
         inputSchema = try container.decode(Value.self, forKey: .inputSchema)
         annotations =
             try container.decodeIfPresent(Tool.Annotations.self, forKey: .annotations) ?? .init()

--- a/Tests/MCPTests/ToolTests.swift
+++ b/Tests/MCPTests/ToolTests.swift
@@ -423,3 +423,20 @@ struct ToolTests {
         }
     }
 }
+
+    @Test("Tool with missing description defaults to empty string")
+    func testToolWithMissingDescription() throws {
+        let jsonString = """
+            {
+                "name": "test_tool",
+                "inputSchema": {}
+            }
+            """
+        let jsonData = jsonString.data(using: .utf8)!
+        
+        let tool = try JSONDecoder().decode(Tool.self, from: jsonData)
+        
+        #expect(tool.name == "test_tool")
+        #expect(tool.description == "")
+        #expect(tool.inputSchema == [:])
+    }

--- a/Tests/MCPTests/ToolTests.swift
+++ b/Tests/MCPTests/ToolTests.swift
@@ -437,6 +437,6 @@ struct ToolTests {
         let tool = try JSONDecoder().decode(Tool.self, from: jsonData)
         
         #expect(tool.name == "test_tool")
-        #expect(tool.description == "")
+        #expect(tool.description == nil)
         #expect(tool.inputSchema == [:])
     }

--- a/Tests/MCPTests/ToolTests.swift
+++ b/Tests/MCPTests/ToolTests.swift
@@ -424,7 +424,7 @@ struct ToolTests {
     }
 }
 
-    @Test("Tool with missing description defaults to empty string")
+    @Test("Tool with missing description")
     func testToolWithMissingDescription() throws {
         let jsonString = """
             {


### PR DESCRIPTION
* description field is not a requried field of Tool

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
