### PR TITLE
Make `Tool.description` optional

### DIFF
--- a/Sources/MCP/Server/Tools.swift
+++ b/Sources/MCP/Server/Tools.swift
@@ -12,7 +12,7 @@ public struct Tool: Hashable, Codable, Sendable {
     /// The tool name
     public let name: String
     /// The tool description
-    public let description: String
+    public let description: String?
     /// The tool input schema
     public let inputSchema: Value
 


### PR DESCRIPTION
Resolves #158 