### PR TITLE
Fix: Move receive() outside loop to fix stream consumption

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,10 +1,10 @@
 {
-  "originHash" : "08de61941b7919a65e36c0e34f8c1c41995469b86a39122158b75b4a68c4527d",
+  "originHash" : "371f3dfcfa1201fc8d50e924ad31f9ebc4f90242924df1275958ac79df15dc12",
   "pins" : [
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/loopwork-ai/eventsource.git",
+      "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
         "revision" : "e83f076811f32757305b8bf69ac92d05626ffdd7",
         "version" : "1.1.0"


### PR DESCRIPTION
## Summary

The Client was calling `connection.receive()` inside a `repeat { } while true` loop, which meant it was trying to iterate the same async stream multiple times. **Async streams can only be iterated once.**

This fix:
- Moves `receive()` outside the loop so the stream is obtained once
- Removes the `repeat { } while true` wrapper (no longer needed)
- Removes EAGAIN handling (was only needed due to the repeat loop)

This aligns with how the TypeScript and Python SDKs handle the receive loop (single stream iteration, no retry loop).

## Before (Bug)
```swift
repeat {
    let stream = await connection.receive()  // ❌ Called on each iteration
    for try await data in stream { ... }
} while true
```

## After (Fix)
```swift
let stream = await connection.receive()  // ✅ Called once
for try await data in stream { ... }
```

## Related

- #175 also addresses this issue as part of a larger update. This PR provides a minimal, focused fix that can be merged independently.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling