### PR TITLE
Update Server Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,10 +433,14 @@ await server.withMethodHandler(ListTools.self) { _ in
         Tool(
             name: "weather",
             description: "Get current weather for a location",
-            inputSchema: .object([
+            inputSchema`: .object([
+                "type": .string("object"),
                 "properties": .object([
-                    "location": .string("City name or coordinates"),
-                    "units": .string("Units of measurement, e.g., metric, imperial")
+                    "location": .object([
+                        "description": .string("City name or coordinates"),
+                        "type": .string("string"),
+                        "units": .string("Units of measurement, e.g., metric, imperial")
+                    ])
                 ])
             ])
         ),
@@ -444,8 +448,12 @@ await server.withMethodHandler(ListTools.self) { _ in
             name: "calculator",
             description: "Perform calculations",
             inputSchema: .object([
+                "type": .string("object"),
                 "properties": .object([
-                    "expression": .string("Mathematical expression to evaluate")
+                    "expression": .object([
+                        "type": .string("string"),
+                        "description": .string("Mathematical expression to evaluate")
+                    ])
                 ])
             ])
         )


### PR DESCRIPTION
This allows tools like mcpInspector to list the tools

Add `type' properties to the `inputSchema` in the documentation sample, and adjust the `properties` as expected by the current specification

## Motivation and Context

The MCP Inspector will not list or use the tools these changes are done (See also [here](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)

## How Has This Been Tested?
With MCP Inspector v0.17.2 and my own [test implementation](https://github.com/below/HelloMCP)

## Breaking Changes
Only Documentation

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Possibly, this should be done automatically.