### PR TITLE
Remove excessive conformance of Value.init(:) parameter to Codable

### DIFF
--- a/Sources/MCP/Base/Value.swift
+++ b/Sources/MCP/Base/Value.swift
@@ -13,10 +13,10 @@ public enum Value: Hashable, Sendable {
     case array([Value])
     case object([String: Value])
 
-    /// Create a `Value` from a `Codable` value.
-    /// - Parameter value: The codable value
+    /// Create a `Value` from an `Encodable` value.
+    /// - Parameter value: The encodable value
     /// - Returns: A value
-    public init<T: Codable>(_ value: T) throws {
+    public init<T: Encodable>(_ value: T) throws {
         if let valueAsValue = value as? Value {
             self = valueAsValue
         } else {


### PR DESCRIPTION
`Value.init(:)` requires its parameter to conform to `Codable` but actually it needs just `Encodable` value.

## Motivation and Context
The current requirement is literally excessive: the initializer encodes the incoming value to `Value`, the same way `JSONEncoder` encodes the incoming value to `Data`.

## How Has This Been Tested?
In my project I was forced to extend conformance of some types to `Decodable` also, while knowing that it is never used.

## Breaking Changes
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
