### PR TITLE
Terminate the client message loop when the transport stream finishes

### DIFF
--- a/Sources/MCP/Base/Utilities/RequestContext.swift
+++ b/Sources/MCP/Base/Utilities/RequestContext.swift
@@ -23,7 +23,15 @@ public struct RequestContext<Output: Sendable & Decodable>: Sendable {
     /// ```
     public var value: Output {
         get async throws {
-            try await requestTask.value
+            // Cancelling the awaiting task cancels the request task, whose
+            // cancellation handler resumes the pending continuation (see
+            // `Client.send`). Awaiting `.value` alone would never forward
+            // cancellation to the unstructured request task.
+            try await withTaskCancellationHandler {
+                try await requestTask.value
+            } onCancel: {
+                requestTask.cancel()
+            }
         }
     }
 

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -181,6 +181,14 @@ public actor Client {
 
     /// A dictionary of type-erased pending requests, keyed by request ID
     private var pendingRequests: [ID: AnyPendingRequest] = [:]
+    /// IDs cancelled before their continuation was registered.
+    ///
+    /// ``send(_:)`` registers the continuation from an unstructured task, so a
+    /// cancellation that lands before that task gets to run finds nothing to
+    /// resume. Without this set the continuation would be registered right
+    /// after and never resumed by anyone: the caller would hang forever on the
+    /// very cancellation meant to free it.
+    private var cancelledBeforeRegistration: Set<ID> = []
     // Add reusable JSON encoder/decoder
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
@@ -303,6 +311,7 @@ public actor Client {
         self.task = nil
         self.connection = nil
         self.pendingRequests = [:]  // Use empty dictionary literal
+        self.cancelledBeforeRegistration = []
 
         // Part 2: Outside actor - Resume continuations, disconnect transport, await task
 
@@ -405,25 +414,35 @@ public actor Client {
         let requestData = try encoder.encode(request)
 
         let requestTask = Task<M.Result, Error> {
-            try await withCheckedThrowingContinuation { continuation in
-                Task {
-                    // Add the pending request before attempting to send
-                    self.addPendingRequest(
-                        id: request.id,
-                        continuation: continuation,
-                        type: M.Result.self
-                    )
+            // Cancellation of the request task removes the pending request,
+            // resumes its continuation with `CancellationError` and notifies
+            // the server (`cancelRequest`). Without this handler the
+            // continuation could only be resumed by a response, so a cancelled
+            // caller (`ping()` with a deadline, a connect with a timeout)
+            // stayed suspended forever.
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    Task {
+                        // Add the pending request before attempting to send
+                        self.addPendingRequest(
+                            id: request.id,
+                            continuation: continuation,
+                            type: M.Result.self
+                        )
 
-                    // Send the request data
-                    do {
-                        try await connection.send(requestData)
-                    } catch {
-                        // If send fails, try to remove the pending request.
-                        if self.removePendingRequest(id: request.id) != nil {
-                            continuation.resume(throwing: error)
+                        // Send the request data
+                        do {
+                            try await connection.send(requestData)
+                        } catch {
+                            // If send fails, try to remove the pending request.
+                            if self.removePendingRequest(id: request.id) != nil {
+                                continuation.resume(throwing: error)
+                            }
                         }
                     }
                 }
+            } onCancel: {
+                Task { try? await self.cancelRequest(request.id, reason: "Task cancelled") }
             }
         }
 
@@ -451,6 +470,10 @@ public actor Client {
         // This ensures any response that arrives after cancellation is ignored
         if let pendingRequest = removePendingRequest(id: requestID) {
             pendingRequest.resume(throwing: CancellationError())
+        } else {
+            // Nothing registered yet: remember the cancellation so that the
+            // registration, when it happens, resumes immediately.
+            cancelledBeforeRegistration.insert(requestID)
         }
 
         // Send cancellation notification to server
@@ -477,6 +500,12 @@ public actor Client {
         continuation: CheckedContinuation<T, Swift.Error>,
         type: T.Type  // Keep type for AnyPendingRequest internal logic
     ) {
+        // Cancelled while this registration was still on its way: resume now,
+        // there is nobody else left to do it.
+        if cancelledBeforeRegistration.remove(id) != nil {
+            continuation.resume(throwing: CancellationError())
+            return
+        }
         pendingRequests[id] = AnyPendingRequest(
             PendingRequest(continuation: continuation)
         )

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -214,9 +214,9 @@ public actor Client {
         // Start message handling loop
         task = Task {
             guard let connection = self.connection else { return }
-            repeat {
+            readLoop: repeat {
                 // Check for cancellation before starting the iteration
-                if Task.isCancelled { break }
+                if Task.isCancelled { break readLoop }
 
                 do {
                     let stream = await connection.receive()
@@ -244,13 +244,21 @@ public actor Client {
                             )
                         }
                     }
+
+                    // The stream finished without throwing: the connection is over.
+                    // No transport reopens a stream once it has finished — every one
+                    // of them finishes it only on EOF, on error, or on disconnect.
+                    // Calling `receive()` again would hand back the very same
+                    // finished stream, so the loop would spin at 100% CPU forever
+                    // instead of terminating.
+                    break readLoop
                 } catch let error where MCPError.isResourceTemporarilyUnavailable(error) {
                     try? await Task.sleep(for: .milliseconds(10))
                     continue
                 } catch {
                     await logger?.error(
                         "Error in message handling loop", metadata: ["error": "\(error)"])
-                    break
+                    break readLoop
                 }
             } while true
             await self.logger?.debug("Client message handling loop task is terminating.")

--- a/Tests/MCPTests/ClientTests.swift
+++ b/Tests/MCPTests/ClientTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 import Testing
 
 @testable import MCP
@@ -771,5 +772,98 @@ struct ClientTests {
         // (If it did, the test would have crashed)
 
         await client.disconnect()
+    }
+
+    @Test("Message loop stops when the transport stream finishes")
+    func testMessageLoopStopsWhenStreamFinishes() async throws {
+        let transport = StreamFinishingTransport()
+        let client = Client(name: "TestClient", version: "1.0")
+
+        // Answer the initialize request so that `connect` can complete.
+        let initTask = Task {
+            try await Task.sleep(for: .milliseconds(10))
+            if let request: Request<Initialize> = await transport.decodeLastSentMessage() {
+                try await transport.queue(
+                    response: Initialize.response(
+                        id: request.id,
+                        result: .init(
+                            protocolVersion: Version.latest,
+                            capabilities: .init(),
+                            serverInfo: .init(name: "TestServer", version: "1.0"),
+                            instructions: nil
+                        )
+                    ))
+            }
+        }
+
+        _ = try await client.connect(transport: transport)
+        initTask.cancel()
+
+        #expect(await transport.receiveCount == 1)
+
+        // The peer goes away: the stream finishes without throwing. This is what
+        // every transport does when the connection is over — StdioTransport on EOF,
+        // HTTPClientTransport and InMemoryTransport on disconnect, NetworkTransport
+        // when it stops. None of them ever reopens a finished stream.
+        await transport.finishStream()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // The message loop must have terminated. Without the fix it called
+        // `receive()` again straight away, got the same finished stream back and
+        // spun at 100% CPU: this count would be in the thousands by now.
+        #expect(await transport.receiveCount == 1)
+
+        await client.disconnect()
+    }
+}
+
+/// A transport that hands out one single-use message stream and counts how many
+/// times the client asks for it, so a test can tell a terminated message loop from
+/// one that keeps re-requesting a stream that has already finished.
+private actor StreamFinishingTransport: Transport {
+    nonisolated let logger = Logger(label: "mcp.test.stream-finishing")
+
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private let stream: AsyncThrowingStream<Data, Swift.Error>
+    private let continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation
+
+    private(set) var receiveCount = 0
+    private(set) var sentData: [Data] = []
+
+    init() {
+        var continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation!
+        self.stream = AsyncThrowingStream { continuation = $0 }
+        self.continuation = continuation
+    }
+
+    func connect() async throws {}
+
+    func disconnect() async {
+        continuation.finish()
+    }
+
+    func send(_ message: Data) async throws {
+        sentData.append(message)
+    }
+
+    func receive() -> AsyncThrowingStream<Data, Swift.Error> {
+        receiveCount += 1
+        return stream
+    }
+
+    func queue<M: MCP.Method>(response: Response<M>) throws {
+        continuation.yield(try encoder.encode(response))
+    }
+
+    func decodeLastSentMessage<T: Decodable>() -> T? {
+        guard let lastMessage = sentData.last else { return nil }
+        return try? decoder.decode(T.self, from: lastMessage)
+    }
+
+    /// Simulates the peer going away: the stream ends without an error.
+    func finishStream() {
+        continuation.finish()
     }
 }


### PR DESCRIPTION
## Problem

`Client.connect(transport:)` runs its message handling loop as a
`repeat { for try await … } while true`, which treats the end of the transport stream
as transient: it exits the `for`, calls `receive()` again and starts over.

No transport behaves that way. Every transport in this repository exposes a
**single-use** stream that finishes only when the connection is over:

| Transport | `finish()` sites | Reopens? |
|---|---|---|
| `StdioTransport` | `readLoop` on EOF/read error, `disconnect()` | no |
| `HTTPClientTransport` | `disconnect()` only | no |
| `InMemoryTransport` | `disconnect()`, peer disconnect | no |
| `NetworkTransport` | `disconnect()` / `isStopping` — its internal reconnect reuses the same continuation without finishing it | no |

Once the stream has finished, `receive()` hands back the very same finished stream, so
the `for` returns immediately and the `while true` starts over immediately. The result is
a busy loop that saturates a core for as long as the `Client` object is alive — and since
the loop's `Task` holds a strong reference to the `Client`, that is forever unless someone
calls `disconnect()`.

Measured in a shipping macOS app: six MCP clients left on dead stdio connections,
**599% CPU** across six spinning threads, with only one server process still running.
A `sample` of the process shows all six threads inside
`closure #1 in Client.connect(transport:)` → `AsyncThrowingStream.Iterator.next()`.

The loop already has the right exit (`break`, in the generic `catch`), but it is only
reachable when the stream *throws* something other than
`Errno.resourceTemporarilyUnavailable`. A stream that finishes cleanly never gets there.

## Fix

Break out of the loop when the stream finishes, the same way the error branch already
does. The `resourceTemporarilyUnavailable` retry — the only legitimate reason for this
loop to repeat — is untouched. The `repeat` is labelled so the `break` inside the `do`
block is unambiguous to the reader.

## Tests

A regression test is included: `Message loop stops when the transport stream finishes`.

`StreamFinishingTransport` hands out one single-use stream and counts how many times the
client asks for it. Once the stream finishes, a client whose loop has terminated never
asks again, so the count stays at 1.

- Against `0.12.1` **without** the fix: fails — the receive count is in the thousands
  after a 100 ms wait.
- **With** the fix: passes.

Full suite: **552 tests in 40 suites passing** (551 before this PR, all unchanged).

The branch was not covered before, which is why the bug survived: `MockTransport.receive()`
creates a new stream on every call and replaces the stored continuation without finishing
the previous one, so in tests the stream never finishes while the client is still
connected.
