### PR TITLE
fix: preserve data-URL-looking JSON strings

### DIFF
--- a/Sources/MCP/Base/Transports/NetworkTransport.swift
+++ b/Sources/MCP/Base/Transports/NetworkTransport.swift
@@ -528,7 +528,7 @@ import Logging
                     completion: .contentProcessed { [weak self] error in
                         guard let self = self else { return }
 
-                        Task { @MainActor in
+                        Task { @MainActor [self] in
                             if !sendContinuationResumed.flag {
                                 sendContinuationResumed.flag = true
                                 if let error = error {

--- a/Sources/MCP/Base/Value.swift
+++ b/Sources/MCP/Base/Value.swift
@@ -9,6 +9,11 @@ public enum Value: Hashable, Sendable {
     case int(Int)
     case double(Double)
     case string(String)
+
+    /// Binary data encoded as a data URL string.
+    ///
+    /// Generic JSON string decoding produces `.string`; use
+    /// `Data.parseDataURL(_:)` to opt in to data-URL parsing.
     case data(mimeType: String? = nil, Data)
     case array([Value])
     case object([String: Value])
@@ -95,13 +100,7 @@ extension Value: Codable {
         } else if let value = try? container.decode(Double.self) {
             self = .double(value)
         } else if let value = try? container.decode(String.self) {
-            if Data.isDataURL(string: value),
-                case let (mimeType, data)? = Data.parseDataURL(value)
-            {
-                self = .data(mimeType: mimeType, data)
-            } else {
-                self = .string(value)
-            }
+            self = .string(value)
         } else if let value = try? container.decode([Value].self) {
             self = .array(value)
         } else if let value = try? container.decode([String: Value].self) {

--- a/Tests/MCPTests/ValueTests.swift
+++ b/Tests/MCPTests/ValueTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+
+@testable import MCP
+
+@Suite("Value Tests")
+struct ValueTests {
+    private let ambiguousJSONStringSamples = [
+        "data:text/plain,Hello%20World",
+        "data:text/plain,Hello World",
+        "data:text/plain;base64,SGVsbG8=",
+        "data:,",
+        "data:text/plain;base64,%%%%",
+        "data:text/plain;base64",
+        "data:text/plain,%E2%9C%93",
+        "data:text/plain,こんにちは%20🌍",
+        "data:application/octet-stream;base64,AAEC/w==",
+    ]
+
+    @Test("A data-URL-looking JSON string decodes as Value.string")
+    func literalDataURLJSONStringDecodesAsString() throws {
+        // Use literal JSON bytes so this test exercises Value.init(from:) without using
+        // JSONEncoder to construct the input.
+        let json = Data(#""data:text/plain,Hello%20World""#.utf8)
+        let decoded = try JSONDecoder().decode(Value.self, from: json)
+
+        guard case .string(let value) = decoded else {
+            Issue.record("Expected Value.string; JSON strings must not be inferred as Value.data")
+            return
+        }
+
+        #expect(value == "data:text/plain,Hello%20World")
+        #expect(value.utf8.elementsEqual("data:text/plain,Hello%20World".utf8))
+    }
+
+    @Test("Data-URL-looking JSON string variants never infer Value.data")
+    func dataURLLookingStringsDecodeAsStrings() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        for string in ambiguousJSONStringSamples {
+            let json = try encoder.encode(string)
+            let decoded = try decoder.decode(Value.self, from: json)
+
+            guard case .string(let decodedString) = decoded else {
+                Issue.record(
+                    "Expected Value.string for JSON string \(String(reflecting: string)); generic JSON decoding must not infer Value.data"
+                )
+                continue
+            }
+
+            #expect(decodedString == string)
+            #expect(decodedString.utf8.elementsEqual(string.utf8))
+        }
+    }
+
+    @Test("Nested data-URL-looking JSON strings remain strings")
+    func nestedDataURLLookingStringsRemainStrings() throws {
+        let expected = Value.object([
+            "array": .array(ambiguousJSONStringSamples.map(Value.string)),
+            "object": .object(
+                Dictionary(
+                    uniqueKeysWithValues: ambiguousJSONStringSamples.enumerated().map {
+                        ("value\($0.offset)", Value.string($0.element))
+                    }
+                )
+            ),
+        ])
+
+        let json = try JSONEncoder().encode(expected)
+        let decoded = try JSONDecoder().decode(Value.self, from: json)
+
+        #expect(decoded == expected)
+    }
+
+    @Test("JSON strings round trip without changing type or spelling")
+    func stringsRoundTripWithoutChangingTypeOrSpelling() throws {
+        let strings = [
+            "",
+            "ordinary text",
+            "slashes / and percent spelling %20 stay text",
+            "Unicode: café ✓ 🌍",
+        ] + ambiguousJSONStringSamples
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        for string in strings {
+            let decoded = try decoder.decode(Value.self, from: encoder.encode(string))
+            let reencoded = try encoder.encode(decoded)
+
+            #expect(decoded == .string(string))
+            #expect(try decoder.decode(String.self, from: reencoded) == string)
+            #expect(try decoder.decode(Value.self, from: reencoded) == .string(string))
+        }
+    }
+
+    @Test("Explicit data values retain data-URL encoding")
+    func explicitDataValuesRetainDataURLEncoding() throws {
+        let value = Value.data(
+            mimeType: "application/octet-stream",
+            Data([0x00, 0x01, 0x02, 0xff])
+        )
+
+        let json = try JSONEncoder().encode(value)
+        let encodedString = try JSONDecoder().decode(String.self, from: json)
+
+        #expect(encodedString == "data:application/octet-stream;base64,AAEC/w==")
+    }
+
+    @Test("A data URL on the JSON wire carries no implicit Value.data tag")
+    func encodedDataURLDecodesGenericallyAsString() throws {
+        let explicitData = Value.data(
+            mimeType: "application/octet-stream",
+            Data([0x00, 0x01, 0x02, 0xff])
+        )
+
+        // Value.data intentionally encodes as a JSON string. Once encoded, its JSON is
+        // indistinguishable from an ordinary string containing the same data URL.
+        let json = try JSONEncoder().encode(explicitData)
+        let decoded = try JSONDecoder().decode(Value.self, from: json)
+
+        #expect(decoded == .string("data:application/octet-stream;base64,AAEC/w=="))
+    }
+
+    @Test("Typed text content remains text through Value erasure")
+    func typedTextContentRemainsTextThroughValueErasure() throws {
+        let original = "data:text/plain,Hello%20World"
+        let result = CallTool.Result(content: [
+            .text(text: original, annotations: nil, _meta: nil)
+        ])
+
+        // MCP explicitly tags this value as text. The SDK erases typed results to Value before
+        // sending them, so generic string decoding must not reinterpret the text as binary data.
+        let erased = try Value(result)
+        let json = try JSONEncoder().encode(erased)
+        let recovered = try JSONDecoder().decode(CallTool.Result.self, from: json)
+
+        #expect(recovered.content.count == 1)
+        guard case .text(let text, _, _) = recovered.content.first else {
+            Issue.record("Expected typed text content")
+            return
+        }
+        #expect(text == original)
+        #expect(text.utf8.elementsEqual(original.utf8))
+    }
+
+    @Test("Typed image and audio content retain explicit fields")
+    func typedBinaryContentRetainsExplicitFields() throws {
+        let cases: [(content: Tool.Content, fields: [String: String])] = [
+            (
+                .image(
+                    data: "SGVsbG8=",
+                    mimeType: "image/png",
+                    annotations: nil,
+                    _meta: nil
+                ),
+                ["type": "image", "data": "SGVsbG8=", "mimeType": "image/png"]
+            ),
+            (
+                .audio(
+                    data: "UklGRg==",
+                    mimeType: "audio/wav",
+                    annotations: nil,
+                    _meta: nil
+                ),
+                ["type": "audio", "data": "UklGRg==", "mimeType": "audio/wav"]
+            ),
+        ]
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        for testCase in cases {
+            let json = try encoder.encode(testCase.content)
+            #expect(try decoder.decode([String: String].self, from: json) == testCase.fields)
+            #expect(try decoder.decode(Tool.Content.self, from: json) == testCase.content)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #277.

Preserves JSON strings decoded through `Value` as `.string`, including strings that match data-URL syntax. Explicit `Value.data` encoding and the data-URL helper APIs remain available, and the public API documentation now clarifies that parsing is opt-in.

## Motivation and Context

`Value.init(from:)` currently interprets any parseable data-URL-looking JSON string as `.data`. Because generic JSON contains no discriminator between an ordinary string and an encoded `Value.data`, this can silently change both the `Value` case and the string's spelling.

For example:

```text
Original: data:text/plain,Hello%20World
Decoded and re-encoded: data:text/plain;base64,SGVsbG8gV29ybGQ=
```

This can also affect content explicitly tagged as MCP text when it passes through generic `Value` conversion.

The change makes the string branch of `Value.init(from:)` always produce `.string`. Applications that intentionally accept data URLs can continue to opt in through `Data.parseDataURL(_:)`, while explicitly constructed `Value.data` values retain their existing encoding.

## How Has This Been Tested?

Added regression coverage for:

- Literal, base64-looking, empty, malformed, percent-encoded, non-ASCII, and `application/octet-stream` data-URL-looking strings
- Strings nested inside arrays and objects
- JSON string type and spelling preservation through round trips
- Explicit `Value.data` encoding
- The absence of an implicit `.data` discriminator on the generic JSON wire
- Typed MCP text content passing through `Value` erasure
- Typed image and audio content serialization

Verification performed:

- `swift test --filter ValueTests`: 8/8 tests passed
- Full Xcode test suite: 559/559 tests passed
- `git diff --check`: clean

The regression tests were also run against the previous decoder implementation to confirm that they reproduce the reported behavior.

## Breaking Changes

This intentionally changes observable behavior for callers that relied on generic `Value` decoding to automatically convert data-URL-looking JSON strings into `.data`.

Those callers will need to explicitly call `Data.parseDataURL(_:)` in fields where data URLs are expected. Encoding an explicitly constructed `Value.data` remains unchanged, as does typed image and audio content serialization.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This behavior was encountered in [bitbemol/second-brain-mcp](https://github.com/bitbemol/second-brain-mcp), which currently vendors the patched SDK pending an upstream resolution.

This is my first contribution to `swift-sdk`. I may be missing context behind the original implicit decoding behavior and am happy to adjust the approach based on maintainer feedback.

AI assistance disclosure: This bug was initially identified with LLM assistance, and Codex assisted with implementation analysis and regression-test development. I personally reviewed the relevant SDK behavior, reproduced the failure in Xcode with the previous decoder, and verified the fix with the complete test suite.
